### PR TITLE
Add CSV export of hike data for trail marker GPS dataset

### DIFF
--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -93,6 +93,7 @@ export default function ActiveHike({ onFinish, onActiveChange }: ActiveHikeProps
       latitude: position.latitude,
       longitude: position.longitude,
       altitude: position.altitude,
+      accuracy: position.accuracy,
     };
   }, [position]);
 

--- a/src/components/HikeHistory.tsx
+++ b/src/components/HikeHistory.tsx
@@ -4,8 +4,9 @@ import {
   loadAttempts,
   saveAttempts,
   formatDuration,
+  exportHikesAsCsv,
 } from "@/lib/hike-store";
-import { Trophy, Calendar, Clock, ChevronRight, Trash2, BarChart3 } from "lucide-react";
+import { Trophy, Calendar, Clock, Trash2, BarChart3, Download } from "lucide-react";
 import HikeComparison from "./HikeComparison";
 
 interface HikeHistoryProps {
@@ -88,9 +89,18 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
         </button>
       )}
 
-      <p className="text-xs uppercase tracking-widest text-muted-foreground mb-3">
-        All Attempts ({completed.length})
-      </p>
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs uppercase tracking-widest text-muted-foreground">
+          All Attempts ({completed.length})
+        </p>
+        <button
+          onClick={() => exportHikesAsCsv(completed)}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+        >
+          <Download className="w-3.5 h-3.5" />
+          Export CSV
+        </button>
+      </div>
 
       <div className="space-y-2">
         {completed.map((a) => {

--- a/src/lib/hike-store.ts
+++ b/src/lib/hike-store.ts
@@ -10,6 +10,7 @@ export interface GpsCoord {
   latitude: number;
   longitude: number;
   altitude: number | null;
+  accuracy?: number;
 }
 
 export interface Split {
@@ -147,4 +148,61 @@ export function formatSplitDiff(current: number, best?: number): { text: string;
   const diff = current - best;
   const sign = diff >= 0 ? "+" : "-";
   return { text: `${sign}${formatDuration(Math.abs(diff))}`, positive: diff <= 0 };
+}
+
+export function exportHikesAsCsv(attempts: HikeAttempt[]): void {
+  const headers = [
+    "Hike ID",
+    "Hike Start Date-Time",
+    "Trail Marker Number",
+    "Trail Number Forgotten",
+    "Trail Marker Timestamp",
+    "Trail Marker GPS Position",
+    "Trail Marker GPS Accuracy (m)",
+  ];
+
+  const rows: string[][] = [];
+  for (const attempt of attempts) {
+    if (!attempt.completed) continue;
+    const startDateTime = new Date(attempt.startTime).toISOString();
+    for (const split of attempt.splits) {
+      const markerTimestamp = new Date(split.timestamp).toISOString();
+      const forgotten = split.skipped ? "true" : "false";
+      let gpsPosition = "";
+      let gpsAccuracy = "";
+      if (split.coords) {
+        const { latitude, longitude, altitude } = split.coords;
+        const altStr = altitude != null ? `,${altitude.toFixed(1)}` : "";
+        gpsPosition = `${latitude.toFixed(7)},${longitude.toFixed(7)}${altStr}`;
+        if (split.coords.accuracy != null) {
+          gpsAccuracy = split.coords.accuracy.toFixed(1);
+        }
+      }
+      rows.push([
+        attempt.id,
+        startDateTime,
+        String(split.marker),
+        forgotten,
+        markerTimestamp,
+        gpsPosition,
+        gpsAccuracy,
+      ]);
+    }
+  }
+
+  const escape = (cell: string) => `"${cell.replace(/"/g, '""')}"`;
+  const csvContent = [
+    headers.map(escape).join(","),
+    ...rows.map((row) => row.map(escape).join(",")),
+  ].join("\n");
+
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `bcmc-hikes-${new Date().toISOString().split("T")[0]}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
Exports all completed hikes as a CSV with one row per trail marker split, including hike ID, start time, marker number, forgotten flag, marker timestamp, GPS position (lat/lng/alt), and GPS accuracy. Accuracy is now also captured and stored in GpsCoord when a marker is tapped.