### PR TITLE
Request persistent storage on app start to reduce iOS PWA eviction risk

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,8 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
+if (navigator.storage?.persist) {
+  navigator.storage.persist();
+}
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
navigator.storage.persist() signals to iOS Safari that this origin's
storage should not be evicted. Supported since iOS 15.4.

https://claude.ai/code/session_01CX1s8YecurD464oZ4rwWfY