### PR TITLE
Update trail stats and add Start/Finish marker rows

### DIFF
--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -202,7 +202,7 @@ export default function ActiveHike({ onFinish, onActiveChange }: ActiveHikeProps
           <Mountain className="w-16 h-16 text-primary" />
           <h1 className="text-3xl font-bold tracking-tight">BCMC Trail</h1>
           <p className="text-muted-foreground text-center text-sm">
-            {TRAIL_DISTANCE_KM} km, {TRAIL_ELEVATION_GAIN}m elevation gain
+            {TRAIL_DISTANCE_KM} km · {TRAIL_ELEVATION_GAIN}m elevation gain
           </p>
           <p className="text-muted-foreground text-center text-xs">
             Start at Grouse Grind timer card trailhead scan

--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -202,7 +202,7 @@ export default function ActiveHike({ onFinish, onActiveChange }: ActiveHikeProps
           <Mountain className="w-16 h-16 text-primary" />
           <h1 className="text-3xl font-bold tracking-tight">BCMC Trail</h1>
           <p className="text-muted-foreground text-center text-sm">
-            {TRAIL_DISTANCE_KM} km · {TRAIL_ELEVATION_GAIN}m elevation gain
+            {TRAIL_DISTANCE_KM} km, {TRAIL_ELEVATION_GAIN}m elevation gain
           </p>
           <p className="text-muted-foreground text-center text-xs">
             Start at Grouse Grind timer card trailhead scan

--- a/src/components/HikeHistory.tsx
+++ b/src/components/HikeHistory.tsx
@@ -51,6 +51,19 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
         markerStats.set(s.marker, { best: Math.min(ex.best, seg), totalMs: ex.totalMs + seg, count: ex.count + 1 });
       }
     }
+    // Finish segment: last marker to end of hike (marker 51)
+    if (a.splits.length > 0 && a.totalTime) {
+      const lastSplit = a.splits[a.splits.length - 1];
+      if (!lastSplit.skipped) {
+        const finishSeg = a.totalTime - lastSplit.elapsed;
+        const ex = markerStats.get(51);
+        if (!ex) {
+          markerStats.set(51, { best: finishSeg, totalMs: finishSeg, count: 1 });
+        } else {
+          markerStats.set(51, { best: Math.min(ex.best, finishSeg), totalMs: ex.totalMs + finishSeg, count: ex.count + 1 });
+        }
+      }
+    }
   }
 
   if (showComparison && comparing.length >= 2) {
@@ -196,6 +209,11 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
                     <span className="text-right">Avg</span>
                   </div>
                   <div className="space-y-0.5">
+                    {/* Start row */}
+                    <div className="grid grid-cols-[1.5rem_1fr_1fr_1fr] gap-x-2 items-center py-1 text-xs">
+                      <span className="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center flex-none bg-primary/20 text-primary">S</span>
+                      <span className="col-span-3 text-muted-foreground italic text-[10px]">Start</span>
+                    </div>
                     {a.splits.map((s, i) => {
                       const prevSplit = a.splits[i - 1];
                       const seg = prevSplit ? s.elapsed - prevSplit.elapsed : s.elapsed;
@@ -225,6 +243,25 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
                         </div>
                       );
                     })}
+                    {/* Finish row */}
+                    {a.splits.length > 0 && !a.splits[a.splits.length - 1].skipped && (() => {
+                      const lastSplit = a.splits[a.splits.length - 1];
+                      const finishSeg = a.totalTime! - lastSplit.elapsed;
+                      const stats = markerStats.get(51);
+                      const avg = stats ? Math.round(stats.totalMs / stats.count) : undefined;
+                      return (
+                        <div className="grid grid-cols-[1.5rem_1fr_1fr_1fr] gap-x-2 items-center py-1 text-xs">
+                          <span className="w-5 h-5 rounded-full text-[10px] font-bold flex items-center justify-center flex-none bg-primary/20 text-primary">F</span>
+                          <span className="font-mono-display text-right">{formatDuration(finishSeg)}</span>
+                          <span className="font-mono-display text-right text-muted-foreground">
+                            {stats ? formatDuration(stats.best) : "—"}
+                          </span>
+                          <span className="font-mono-display text-right text-muted-foreground">
+                            {avg !== undefined ? formatDuration(avg) : "—"}
+                          </span>
+                        </div>
+                      );
+                    })()}
                   </div>
                 </div>
               )}

--- a/src/lib/hike-store.ts
+++ b/src/lib/hike-store.ts
@@ -1,9 +1,9 @@
 // BCMC Trail — markers up to ~50 (unconfirmed exact count)
-// Official stats from grousemountain.com/BCMC: 2.9 km, 750m elevation gain
+// Official stats from grousemountain.com/BCMC: 2.4 km, 796m elevation gain
 
 export const MAX_MARKERS = 50;
-export const TRAIL_DISTANCE_KM = 2.9;
-export const TRAIL_ELEVATION_GAIN = 750;
+export const TRAIL_DISTANCE_KM = 2.4;
+export const TRAIL_ELEVATION_GAIN = 796;
 export const TRAIL_BASE_ELEVATION = 290;
 
 export interface GpsCoord {
@@ -165,6 +165,16 @@ export function exportHikesAsCsv(attempts: HikeAttempt[]): void {
   for (const attempt of attempts) {
     if (!attempt.completed) continue;
     const startDateTime = new Date(attempt.startTime).toISOString();
+    // Start row (marker 0)
+    rows.push([
+      attempt.id,
+      startDateTime,
+      "0",
+      "false",
+      startDateTime,
+      "",
+      "",
+    ]);
     for (const split of attempt.splits) {
       const markerTimestamp = new Date(split.timestamp).toISOString();
       const forgotten = split.skipped ? "true" : "false";
@@ -186,6 +196,18 @@ export function exportHikesAsCsv(attempts: HikeAttempt[]): void {
         markerTimestamp,
         gpsPosition,
         gpsAccuracy,
+      ]);
+    }
+    // Finish row (marker 51)
+    if (attempt.endTime) {
+      rows.push([
+        attempt.id,
+        startDateTime,
+        "51",
+        "false",
+        new Date(attempt.endTime).toISOString(),
+        "",
+        "",
       ]);
     }
   }


### PR DESCRIPTION
- Update trail subtitle to 2.4 km, 796m elevation gain
- Add Start (S) and Finish (F) rows to expanded hike marker list in history view
- Include Start (marker 0) and Finish (marker 51) rows in CSV export

https://claude.ai/code/session_0178DFhrAwF9yN3wreKCbP3s