### PR TITLE
claude/caveman-feature-lMzEn

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,7 +24,7 @@ export default function Index() {
   return (
     <div className="h-screen flex flex-col max-w-md mx-auto">
       {/* Content */}
-      <div className="flex-1 min-h-0">
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {tab === "track" ? (
           <ActiveHike onFinish={() => { setHikeActive(false); refresh(); setTab("history"); }} onActiveChange={setHikeActive} />
         ) : (


### PR DESCRIPTION
Add overflow-y-auto to content area so expanded hike cards scroll
within the flex container instead of overflowing the viewport and
pushing the bottom nav off screen.

https://claude.ai/code/session_015kUQ7kCEnvB8bF18VjkeeV