### PR TITLE
Implement OLED battery saving mode for locked hike screen

### DIFF
--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -236,7 +236,7 @@ export default function ActiveHike({ onFinish, onActiveChange }: ActiveHikeProps
   }
 
   return (
-    <div className="flex flex-col h-full relative">
+    <div className={`flex flex-col h-full relative${isLocked ? " hike-screen-locked" : ""}`}>
       {/* Timer — sits above the lock overlay so the time stays visible */}
       <div className="flex-none bg-background border-b border-border px-6 py-4 relative z-20">
         <div className="flex items-start justify-between">

--- a/src/index.css
+++ b/src/index.css
@@ -4,43 +4,43 @@
 
 @layer base {
   :root {
-    --background: 150 10% 8%;
+    --background: 0 0% 0%;
     --foreground: 45 20% 92%;
 
-    --card: 150 8% 12%;
+    --card: 0 0% 3%;
     --card-foreground: 45 20% 92%;
 
-    --popover: 150 8% 12%;
+    --popover: 0 0% 3%;
     --popover-foreground: 45 20% 92%;
 
     --primary: 145 60% 45%;
-    --primary-foreground: 150 10% 8%;
+    --primary-foreground: 0 0% 0%;
 
     --secondary: 30 40% 30%;
     --secondary-foreground: 45 20% 92%;
 
-    --muted: 150 6% 18%;
+    --muted: 0 0% 10%;
     --muted-foreground: 150 10% 55%;
 
     --accent: 35 80% 55%;
-    --accent-foreground: 150 10% 8%;
+    --accent-foreground: 0 0% 0%;
 
     --destructive: 0 72% 51%;
     --destructive-foreground: 45 20% 92%;
 
-    --border: 150 6% 20%;
-    --input: 150 6% 20%;
+    --border: 0 0% 12%;
+    --input: 0 0% 12%;
     --ring: 145 60% 45%;
 
     --radius: 0.75rem;
 
-    --sidebar-background: 150 8% 10%;
+    --sidebar-background: 0 0% 5%;
     --sidebar-foreground: 45 20% 92%;
     --sidebar-primary: 145 60% 45%;
-    --sidebar-primary-foreground: 150 10% 8%;
-    --sidebar-accent: 150 6% 18%;
+    --sidebar-primary-foreground: 0 0% 0%;
+    --sidebar-accent: 0 0% 10%;
     --sidebar-accent-foreground: 45 20% 92%;
-    --sidebar-border: 150 6% 20%;
+    --sidebar-border: 0 0% 12%;
     --sidebar-ring: 145 60% 45%;
 
     --success: 145 60% 45%;
@@ -74,10 +74,22 @@
   pointer-events: none;
   background: radial-gradient(
     circle at 50% 50%,
-    hsla(150, 10%, 8%, 0.55) 0,
-    hsla(150, 10%, 8%, 0.30) 18%,
-    hsla(150, 10%, 8%, 0.0) 45%
+    hsla(0, 0%, 0%, 0.55) 0,
+    hsla(0, 0%, 0%, 0.30) 18%,
+    hsla(0, 0%, 0%, 0.0) 45%
   );
+}
+
+/* Dim foreground color tokens when the hike screen is locked (OLED battery saving).
+   Background/card remain true-black at all times; only the lit pixels are reduced here. */
+.hike-screen-locked {
+  --timer: 145 50% 50%;
+  --primary: 145 55% 30%;
+  --success: 145 55% 30%;
+  --warning: 35 55% 35%;
+  --destructive: 0 55% 35%;
+  --foreground: 45 15% 60%;
+  --muted-foreground: 150 8% 30%;
 }
 
 /* Translucent marker button — map reads through via backdrop-filter */


### PR DESCRIPTION
## Summary
This PR implements an OLED battery-saving mode for the hike screen when locked. The changes include a complete redesign of the color scheme to use true black backgrounds and dimmed foreground colors, along with a new `.hike-screen-locked` CSS class that reduces lit pixels when the screen is locked.

## Key Changes
- **Color scheme overhaul**: Replaced the green-tinted color palette (hue 150) with a neutral black/grayscale palette throughout the CSS variables
  - Background changed from `150 10% 8%` to `0 0% 0%` (true black)
  - Card and popover backgrounds changed to `0 0% 3%` (near-black)
  - Border and input colors adjusted to `0 0% 12%` for better contrast on black
  - Sidebar background changed to `0 0% 5%` (darker)
  - All primary-foreground and accent-foreground colors changed to true black

- **New `.hike-screen-locked` CSS class**: Applies additional color dimming when the hike screen is locked
  - Reduces brightness of timer, primary, success, warning, and destructive colors
  - Dims foreground and muted-foreground text colors to reduce OLED pixel brightness
  - Preserves true-black backgrounds at all times for maximum battery savings

- **ActiveHike component update**: Conditionally applies the `hike-screen-locked` class to the main container when the screen is locked

## Implementation Details
The OLED battery-saving strategy keeps background/card colors at true black (0% brightness) at all times, while only the foreground/text colors are dimmed when locked. This maximizes the battery-saving benefit on OLED displays where black pixels consume minimal power.

https://claude.ai/code/session_01FdS5W8TiudGjjoxuYapUxX