### PR TITLE
Fix PWA/Safari black screen caused by missing optional chaining on orientation lock

### DIFF
--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -14,6 +14,7 @@ import {
   saveAttempts,
   loadAttempts,
   createAttempt,
+  generateId,
   recordMarkerGps,
   saveActiveHike,
   loadActiveHike,
@@ -140,7 +141,7 @@ export default function ActiveHike({ onFinish, onActiveChange }: ActiveHikeProps
     if (!text) return;
     const now = Date.now();
     const tag: HikeTag = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       timestamp: now,
       elapsed: now - attempt.startTime,
       text,

--- a/src/lib/hike-store.ts
+++ b/src/lib/hike-store.ts
@@ -63,6 +63,16 @@ export interface MarkerGpsData {
   [marker: number]: { latitudes: number[]; longitudes: number[]; altitudes: number[] };
 }
 
+export function generateId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}
+
 const STORAGE_KEY = "bcmc-hike-attempts";
 const MARKER_GPS_KEY = "bcmc-marker-gps";
 const ACTIVE_HIKE_KEY = "bcmc-active-hike";
@@ -148,7 +158,7 @@ export function getAverageMarkerPositions(): Map<number, { lat: number; lng: num
 
 export function createAttempt(): HikeAttempt {
   return {
-    id: crypto.randomUUID(),
+    id: generateId(),
     date: new Date().toISOString(),
     startTime: Date.now(),
     splits: [],

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,7 +12,7 @@ export default function Index() {
   const [hikeActive, setHikeActive] = useState(false);
 
   useEffect(() => {
-    screen.orientation?.lock?.("portrait").catch(() => {});
+    screen.orientation?.lock?.("portrait")?.catch(() => {});
   }, []);
 
   const refresh = useCallback(() => setAttempts(loadAttempts()), []);


### PR DESCRIPTION
screen.orientation?.lock?.("portrait") returns undefined on Safari/iOS
where lock() is not implemented. Calling .catch() (non-optional) on
undefined throws a TypeError that — with no error boundary in the tree —
unmounts the entire React root and shows the pure-black CSS background.

Fix: add ?. before .catch() so the call short-circuits on undefined.

Also replace crypto.randomUUID() (Safari < 15.4) with a generateId()
helper that falls back to a Math.random()-based UUID to prevent crashes
when starting a hike or adding a tag on older Safari versions.

https://claude.ai/code/session_01PnRibx2c7SVMLkZbUnmqbu