### PR TITLE
Add help page, GoatCounter analytics, and integer versioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Grouse Split Tracker">
     <meta name="twitter:description" content="Lightweight app to track trail marker segments and total hike time for the BCMC. Will add the Grouse Grind when it reopens.">
+
+    <script data-goatcounter="https://grouse-split-tracker.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
 </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grouse-split-tracker",
   "private": true,
-  "version": "0.0.0",
+  "version": "1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -274,6 +274,7 @@ export default function ActiveHike({ onFinish, onActiveChange }: ActiveHikeProps
     saveActiveHike(a);
     setElapsed(0);
     setIsRunning(true);
+    window.goatcounter?.count({ path: "hike-start", title: "Hike Started", event: true });
     // startCoords is captured from the first GPS fix after start — see the effect below.
   }, []);
 

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -29,7 +29,9 @@ export default function HelpModal({ open, onOpenChange }: HelpModalProps) {
           <p className="text-muted-foreground">
             Track your split times at each numbered marker on the BCMC trail —
             50 markers over 2.52 km and 796 m of elevation gain. All data stays
-            on your device. No account required.
+            on your device. No account required. The app is designed to work
+            offline once loaded — install it to your home screen for the best
+            experience on trail.
           </p>
 
           {/* Getting started */}
@@ -117,8 +119,7 @@ export default function HelpModal({ open, onOpenChange }: HelpModalProps) {
               <li>Let GPS settle to a green dot before tapping START.</li>
               <li>
                 The screen stays on automatically during an active hike (wake
-                lock). Install to your home screen for the best offline
-                experience.
+                lock).
               </li>
               <li>
                 When the button shows <strong className="text-foreground">Approaching N</strong>, you

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -134,6 +134,16 @@ export default function HelpModal({ open, onOpenChange }: HelpModalProps) {
           </section>
 
           {/* Build info */}
+          <section className="border-t border-border pt-3 text-xs text-muted-foreground">
+            <p className="mb-2">
+              This app uses{" "}
+              <span className="text-foreground font-medium">GoatCounter</span>{" "}
+              for basic, privacy-preserving usage counting — no cookies, no
+              fingerprinting, no personal data. Only two events are counted:
+              page loads and hike starts.
+            </p>
+          </section>
+
           <section className="border-t border-border pt-3 text-xs text-muted-foreground space-y-0.5">
             <div className="flex justify-between">
               <span>Version</span>

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -77,8 +77,10 @@ export default function HelpModal({ open, onOpenChange }: HelpModalProps) {
             <h3 className="font-semibold mb-1.5">Features</h3>
             <ul className="space-y-1 text-muted-foreground list-disc list-inside">
               <li>
-                <strong className="text-foreground">Forgot a marker?</strong> Tap the{" "}
-                <strong className="text-foreground">Forgot</strong> button to log it retroactively.
+                <strong className="text-foreground">Missed a marker?</strong> Tap{" "}
+                <strong className="text-foreground">Forgot marker N</strong> to skip past it and keep
+                the app in sync. The current time is recorded but no GPS
+                position is saved for that marker.
               </li>
               <li>
                 <strong className="text-foreground">Tags.</strong> Tap the tag button to drop a
@@ -119,9 +121,10 @@ export default function HelpModal({ open, onOpenChange }: HelpModalProps) {
                 experience.
               </li>
               <li>
-                If Auto mode fires a few metres early on a switchback, tap the
-                button immediately to override and commit at your actual
-                position.
+                When the button shows <strong className="text-foreground">Approaching N</strong>, you
+                can tap it to commit immediately at your live GPS position
+                instead of waiting for the auto zone-exit. Once auto has
+                already fired and the marker advances, there is no undo.
               </li>
               <li>
                 Export a CSV after important hikes — localStorage can be

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -27,11 +27,28 @@ export default function HelpModal({ open, onOpenChange }: HelpModalProps) {
         <div className="space-y-4 text-sm">
           {/* Use case */}
           <p className="text-muted-foreground">
-            Track your split times at each numbered marker on the BCMC trail —
-            50 markers over 2.52 km and 796 m of elevation gain. All data stays
-            on your device. No account required. The app is designed to work
-            offline once loaded — install it to your home screen for the best
-            experience on trail.
+            Human Intro:
+            This is a vibe-coded app primarily designed for my specific needs
+            hiking the Grind and the BCMC. I wanted something free, lightweight,
+            and able to track split times between markers so I can figure out how
+            to get my Grind time under an hour.
+
+            I've been pretty hands-off with the code but guided UI and behaviour
+            from hiking the BCMC and iterating the app on my iPhone 15 Pro.
+            
+            This is a website that serves up a big Javascript file that runs locally
+            on your phone. All data stays on-device. There are no accounts, no social,
+            no Google/Meta/Big Brother analytics, no cookies. I'm using <a href="https://www.goatcounter.com">Goatcounter</a> for
+            a privacy-preserving usage counter that increments once per Start button push.
+            The app is designed to work offline once loaded, since coverage can be spotty
+            Install it to your home screen for the best experience on trail. This tells
+            iOS not to be too aggressive in killing the app or deleting its data, like
+            it would be if you ran it inside a browser.
+
+            That's it for the human part! The rest of this thing is AI, except for the
+            trail markers, which I manually logged.
+
+            I will add the Grind once it opens for the 2026 season.
           </p>
 
           {/* Getting started */}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,3 +3,9 @@
 declare const __APP_VERSION__: string;
 declare const __COMMIT_HASH__: string;
 declare const __BUILD_DATE__: string;
+
+interface Window {
+  goatcounter?: {
+    count: (opts: { path: string; title?: string; event?: boolean }) => void;
+  };
+}


### PR DESCRIPTION
## Summary

- **Help modal** — `?` button (top-left, always visible) opens a scrollable guide covering use case, getting started steps, Auto vs Manual mode, features, tips, and a privacy note. Verified all descriptions against the source code (Forgot = skip to stay in sync; tap override only works while "Approaching N" is shown).
- **Build info** — `vite.config.ts` bakes version, git commit hash, and build date into the bundle; displayed in the help modal footer so users always know which build they're on.
- **Integer versioning** — `package.json` version bumped to `1`. After merging, tag `v1` on main: `git tag v1 && git push origin v1`
- **GoatCounter analytics** — script tag in `index.html` counts page loads; `handleStart` fires a `hike-start` event on START tap. No cookies, no fingerprinting. Privacy note added to help modal.

## Test plan

- [ ] Tap `?` — modal opens, content is readable and scrollable
- [ ] Build info footer shows version `1`, a short commit hash, and a date
- [ ] Tap START on the Track tab — confirm a `hike-start` event appears in the GoatCounter dashboard
- [ ] Page load appears in GoatCounter dashboard
- [ ] Forgot marker advances marker counter without recording coords
- [ ] Help modal accessible from both Track and History tabs, and during an active hike

https://claude.ai/code/session_01A9k88ciE3fMLTHYjUzqdt1