### PR TITLE
Auto-advance marker dropdown after tagging

### DIFF
--- a/src/components/MarkerCollector.tsx
+++ b/src/components/MarkerCollector.tsx
@@ -128,6 +128,11 @@ export default function MarkerCollector({
 
     setTags(await getAllMarkerTags());
     setCurrentTag(tag);
+
+    const currentIndex = MARKERS.indexOf(selectedMarker);
+    if (currentIndex !== -1 && currentIndex < MARKERS.length - 1) {
+      setSelectedMarker(MARKERS[currentIndex + 1]);
+    }
   };
 
   const handleExport = async () => {


### PR DESCRIPTION
## Summary

- After successfully tagging a marker in the "Tag Trail Markers" interface, `selectedMarker` automatically advances to the next marker in the list
- If the last marker is already selected, it stays put (no wrap-around)

## Test plan

- [ ] Open the Tag Trail Markers modal with GPS active
- [ ] Tag a marker and confirm the dropdown jumps to the next marker automatically
- [ ] Tag the last marker (40) and confirm the dropdown does not advance past it
- [ ] Manually changing the dropdown still works as before

https://claude.ai/code/session_01QE3cb8DcnPHbkaDSzXFDRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE3cb8DcnPHbkaDSzXFDRN)_