### PR TITLE
Export collected marker tags as named GPX waypoints

### DIFF
--- a/src/components/MarkerCollector.tsx
+++ b/src/components/MarkerCollector.tsx
@@ -137,7 +137,7 @@ export default function MarkerCollector({
 
   const handleExport = async () => {
     const csv = exportMarkersAsCSV(tags);
-    const gpx = exportTrailAsGPX();
+    const gpx = exportTrailAsGPX(tags);
 
     const now = new Date().toISOString().split("T")[0];
     downloadFile(csv, `grind-markers-${now}.csv`);

--- a/src/lib/marker-collector-export.ts
+++ b/src/lib/marker-collector-export.ts
@@ -15,7 +15,7 @@ export function exportMarkersAsCSV(tags: MarkerTag[]): string {
   return lines.join("\n");
 }
 
-export function exportTrailAsGPX(): string {
+export function exportTrailAsGPX(tags: MarkerTag[] = []): string {
   const now = new Date().toISOString();
 
   let gpx = `<?xml version="1.0" encoding="UTF-8"?>
@@ -24,7 +24,20 @@ export function exportTrailAsGPX(): string {
     <name>Grouse Grind Trail</name>
     <time>${now}</time>
   </metadata>
-  <trk>
+`;
+
+  const sorted = [...tags].sort((a, b) => a.marker - b.marker);
+  sorted.forEach((tag) => {
+    gpx += `  <wpt lat="${tag.lat.toFixed(7)}" lon="${tag.lng.toFixed(7)}">
+    <ele>${tag.elevation.toFixed(2)}</ele>
+    <time>${new Date(tag.timestamp).toISOString()}</time>
+    <name>Marker ${tag.marker}</name>
+    <desc>accuracy=${tag.accuracy.toFixed(1)}m</desc>
+  </wpt>
+`;
+  });
+
+  gpx += `  <trk>
     <name>Grouse Grind Trail</name>
     <trkseg>
 `;


### PR DESCRIPTION
## Summary

- `exportTrailAsGPX` now accepts the user-collected `MarkerTag[]` and writes each tag as a `<wpt>` waypoint element before the track segment
- Each waypoint carries `<name>Marker N</name>`, elevation, timestamp, and accuracy in `<desc>`
- Updated `MarkerCollector.tsx` to pass `tags` to `exportTrailAsGPX` at export time
- The CSV export was already correct; only the GPX was missing marker numbers and collected positions

## Test plan

- [ ] Tag several markers in the MarkerCollector UI
- [ ] Hit Export and open the `.gpx` file
- [ ] Verify `<wpt>` elements appear for each tagged marker with the correct `<name>Marker N</name>` attribute
- [ ] Verify the static trail route `<trkseg>` is still present and intact
- [ ] Confirm the `.csv` export is unchanged

https://claude.ai/code/session_01Xpf263VDheCAyy24XzyaGz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpf263VDheCAyy24XzyaGz)_