### PR TITLE
Tier 1 tracking accuracy: along-trail snap + raw GPS log

### DIFF
--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -26,6 +26,7 @@ import {
   isMarkerMissing,
   haversineM,
   snapToMasterTrail,
+  alongTrailDistanceToMarker,
   interpolateMarkerProgress,
   type Trail,
   type MarkerProgress,
@@ -46,11 +47,19 @@ const LOCK_HOLD_MS = 1000;
 const UNLOCK_HOLD_MS = 2000;
 const LOCK_RING_CIRC = 2 * Math.PI * 44; // circumference for r=44 in the centered progress indicator
 
-// Auto-tracking tunables. Design params from issue #36.
-const GPS_ACCURACY_MAX_M = 30; // above this, force Manual mode
+// Auto-tracking tunables. Design params from issue #36, with Tier 1 accuracy bumps.
+//
+// Approach detection now uses *along-trail* signed distance (snap GPS to the trail
+// polyline first, subtract from the next marker's stored distanceM) instead of raw
+// great-circle distance. Cross-trail GPS noise no longer inflates the apparent
+// distance to a marker, so the accuracy threshold for Auto mode can be raised.
+const GPS_ACCURACY_MAX_M = 50; // raw accuracy ceiling above which Auto disables
 const APPROACH_RADIUS_MIN_M = 15;
-const APPROACH_RADIUS_ACCURACY_FACTOR = 1.5;
+const APPROACH_RADIUS_ACCURACY_FACTOR = 1.0; // shrunk from 1.5 — along-trail residual is ~1× σ_GPS
 const EXIT_INCREASING_FIXES = 2; // consecutive rising-distance fixes that trigger commit
+
+// Throttle for raw GPS track capture (skips fixes arriving faster than this).
+const GPS_TRACK_MIN_INTERVAL_MS = 800;
 
 interface ApproachState {
   marker: number;
@@ -137,6 +146,35 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
     }
   }, [position, isRunning]);
 
+  // Raw GPS track capture — one row per accepted fix (throttled). Stored on the
+  // attempt for offline analysis + future filter iteration. Throttle dedupes the
+  // burst of identical synthetic fixes the dev SimPanel emits without dropping
+  // legitimate ~1 Hz device updates.
+  useEffect(() => {
+    if (!isRunning || !attempt || !position) return;
+    setAttempt((prev) => {
+      if (!prev) return prev;
+      const t = Date.now() - prev.startTime;
+      const last = prev.gpsTrack && prev.gpsTrack.length > 0
+        ? prev.gpsTrack[prev.gpsTrack.length - 1]
+        : null;
+      if (last && t - last.t < GPS_TRACK_MIN_INTERVAL_MS) return prev;
+      const fix = {
+        t,
+        lat: position.latitude,
+        lng: position.longitude,
+        acc: position.accuracy,
+        alt: position.altitude,
+        altAcc: position.altitudeAccuracy,
+        heading: position.heading,
+        speed: position.speed,
+      };
+      const updated = { ...prev, gpsTrack: [...(prev.gpsTrack ?? []), fix] };
+      saveActiveHike(updated);
+      return updated;
+    });
+  }, [position, isRunning, attempt]);
+
   // Cleanup lock hold timer on unmount
   useEffect(() => {
     return () => clearInterval(lockHoldRef.current);
@@ -150,17 +188,13 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
   const mode: SplitMode = !userForcedManual && nextMarkerPos && gpsAccurate ? "auto" : "manual";
 
   // Live distance to the next marker, shown under the marker number while Auto is armed.
-  // Prefer along-trail distance (snap current GPS to master trail, subtract from the
-  // marker's known trail distance). Fall back to great-circle haversine when the snap
-  // says we're past the marker (negative delta).
+  // Uses along-trail signed distance via snap-to-segment projection, falling back to
+  // straight-line haversine only when the marker has no stored progress in the table.
   const distanceToNextMarkerM: number | null = (() => {
     if (mode !== "auto" || !nextMarkerPos || !position) return null;
-    const nextRec = getProgressForMarker(trail, nextMarker);
-    const straightM = haversineM(position.latitude, position.longitude, nextMarkerPos.lat, nextMarkerPos.lng);
-    if (nextRec.marker !== nextMarker) return straightM;
-    const snappedM = snapToMasterTrail(trail, position.latitude, position.longitude).distanceM;
-    const trailDeltaM = nextRec.distanceM - snappedM;
-    return trailDeltaM > 0 ? trailDeltaM : straightM;
+    const along = alongTrailDistanceToMarker(trail, position.latitude, position.longitude, nextMarker);
+    if (along !== null) return Math.max(0, along);
+    return haversineM(position.latitude, position.longitude, nextMarkerPos.lat, nextMarkerPos.lng);
   })();
 
   const toggleManualOverride = useCallback(() => {
@@ -239,7 +273,13 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
       return;
     }
 
-    const distM = haversineM(position.latitude, position.longitude, nextMarkerPos.lat, nextMarkerPos.lng);
+    // Along-trail signed distance preferred — kills cross-trail GPS noise. Fall back to
+    // raw haversine if the marker has no entry in the trail's distance table (shouldn't
+    // happen for known markers but keeps the code safe).
+    const alongRaw = alongTrailDistanceToMarker(trail, position.latitude, position.longitude, nextMarker);
+    const distM = alongRaw !== null
+      ? Math.abs(alongRaw)
+      : haversineM(position.latitude, position.longitude, nextMarkerPos.lat, nextMarkerPos.lng);
     const radius = Math.max(APPROACH_RADIUS_MIN_M, position.accuracy * APPROACH_RADIUS_ACCURACY_FACTOR);
     const coord: GpsCoord = {
       latitude: position.latitude,

--- a/src/components/HikeHistory.tsx
+++ b/src/components/HikeHistory.tsx
@@ -5,6 +5,7 @@ import {
   saveAttempts,
   formatDuration,
   exportHikesAsCsv,
+  exportGpsTracksAsCsv,
   attemptTrailId,
   loadHistoryFilter,
   saveHistoryFilter,
@@ -213,13 +214,24 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
         <p className="text-xs uppercase tracking-widest text-muted-foreground">
           All Attempts ({visible.length}{visible.length !== completed.length ? ` of ${completed.length}` : ""})
         </p>
-        <button
-          onClick={() => exportHikesAsCsv(visible)}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
-        >
-          <Download className="w-3.5 h-3.5" />
-          Export CSV
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => exportHikesAsCsv(visible)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+          >
+            <Download className="w-3.5 h-3.5" />
+            Splits CSV
+          </button>
+          <button
+            onClick={() => exportGpsTracksAsCsv(visible)}
+            disabled={!visible.some((a) => a.gpsTrack && a.gpsTrack.length > 0)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors disabled:opacity-40 disabled:hover:text-muted-foreground"
+            title="One row per raw GPS fix (only available on hikes recorded after the gpsTrack feature)"
+          >
+            <Download className="w-3.5 h-3.5" />
+            GPS track CSV
+          </button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/src/hooks/use-gps.ts
+++ b/src/hooks/use-gps.ts
@@ -6,6 +6,8 @@ export interface GpsPosition {
   altitude: number | null;
   accuracy: number;
   altitudeAccuracy: number | null;
+  heading: number | null;
+  speed: number | null;
   timestamp: number;
 }
 
@@ -29,6 +31,8 @@ export function useGps(active: boolean) {
           altitude: pos.coords.altitude,
           accuracy: pos.coords.accuracy,
           altitudeAccuracy: pos.coords.altitudeAccuracy,
+          heading: pos.coords.heading,
+          speed: pos.coords.speed,
           timestamp: pos.timestamp,
         });
         setError(null);

--- a/src/lib/gps-simulator.ts
+++ b/src/lib/gps-simulator.ts
@@ -73,7 +73,7 @@ function fixAtDistance(trail: Trail, cumDistM: number[], totalDistM: number, dis
   };
 }
 
-function makeGeolocationPosition(fix: SimFix): GeolocationPosition {
+function makeGeolocationPosition(fix: SimFix, speed: number | null, heading: number | null): GeolocationPosition {
   const ts = Date.now();
   const coords: GeolocationCoordinates = {
     latitude: fix.lat,
@@ -81,8 +81,8 @@ function makeGeolocationPosition(fix: SimFix): GeolocationPosition {
     altitude: fix.ele,
     accuracy: fix.accuracy,
     altitudeAccuracy: 1,
-    heading: null,
-    speed: null,
+    heading,
+    speed,
     toJSON() {
       return { ...this };
     },
@@ -98,24 +98,31 @@ function makeGeolocationPosition(fix: SimFix): GeolocationPosition {
 
 function tick() {
   if (!state || state.paused) return;
-  const advanceM = (state.options.metersPerSecond * state.options.tickMs) / 1000;
   state.elapsedTrailSec += state.options.tickMs / 1000;
   const distM = Math.min(state.totalDistM, state.options.metersPerSecond * state.elapsedTrailSec);
   const fix = fixAtDistance(state.options.trail, state.cumDistM, state.totalDistM, distM);
   const opts = state.options;
   const isPoor = Math.random() < opts.poorFixProbability;
   fix.accuracy = isPoor ? opts.poorFixAccuracyM : opts.baseAccuracyM;
-  const pos = makeGeolocationPosition(fix);
-  for (const { ok } of state.watchers.values()) {
-    try { ok(pos); } catch { /* ignore */ }
-  }
+
+  // Synthetic heading from delta to next route vertex.
   let idx = 0;
   for (let i = 0; i < state.cumDistM.length - 1; i++) {
     if (state.cumDistM[i] <= distM) idx = i;
   }
+  const route = state.options.trail.route;
+  const nextV = route[Math.min(idx + 1, route.length - 1)];
+  const dLat = nextV.lat - fix.lat;
+  const dLng = nextV.lng - fix.lng;
+  const heading = (Math.atan2(dLng, dLat) * 180) / Math.PI;
+  const headingNorm = ((heading % 360) + 360) % 360;
+  const speed = opts.metersPerSecond;
+
+  const pos = makeGeolocationPosition(fix, speed, headingNorm);
+  for (const { ok } of state.watchers.values()) {
+    try { ok(pos); } catch { /* ignore */ }
+  }
   opts.onProgress?.({ distM, totalM: state.totalDistM, idx, lat: fix.lat, lng: fix.lng, accuracy: fix.accuracy });
-  // Suppress unused warning for advanceM.
-  void advanceM;
 }
 
 export function installGpsSimulator(options: SimOptions) {

--- a/src/lib/hike-store.ts
+++ b/src/lib/hike-store.ts
@@ -42,6 +42,26 @@ export interface HikeTag {
   coords?: GpsCoord; // saved but not exported / not shown in UI
 }
 
+/**
+ * Raw GPS fix captured during a hike. One row per accepted geolocation update
+ * (throttled to ~1 Hz). Stored in HikeAttempt.gpsTrack for offline analysis +
+ * future algorithm iterations (e.g. trail-aware filters, altitude fusion).
+ *
+ * All fields are optional/nullable to mirror what the Geolocation API exposes;
+ * iOS Safari typically returns useful altitude/altitudeAccuracy when the
+ * device has a barometer + GPS lock.
+ */
+export interface GpsFix {
+  t: number;            // ms since hike start
+  lat: number;
+  lng: number;
+  acc: number;          // accuracy radius in metres
+  alt: number | null;   // altitude in metres (often barometric on iOS)
+  altAcc: number | null;
+  heading: number | null;
+  speed: number | null;
+}
+
 export interface HikeAttempt {
   id: string;
   date: string; // ISO string
@@ -59,6 +79,8 @@ export interface HikeAttempt {
   tags?: HikeTag[];
   // Trail this attempt was logged on. Older attempts without this field are treated as BCMC.
   trailId?: TrailId;
+  // Raw GPS fix stream throttled to ~1 Hz. Optional — older hikes won't have it.
+  gpsTrack?: GpsFix[];
 }
 
 // Averaged GPS coordinates per marker across all attempts
@@ -355,6 +377,68 @@ export function exportHikesAsCsv(attempts: HikeAttempt[]): void {
   const link = document.createElement("a");
   link.href = url;
   link.download = `hikes-${new Date().toISOString().split("T")[0]}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Export the raw GPS track from completed hikes — one row per fix. Supports
+ * offline analysis + future algorithm iteration (snap-to-segment, altitude
+ * fusion, Kalman filtering). Hikes recorded before gpsTrack was introduced
+ * are skipped.
+ */
+export function exportGpsTracksAsCsv(attempts: HikeAttempt[]): void {
+  const headers = [
+    "Hike ID",
+    "Trail",
+    "Hike Start Date-Time",
+    "Fix Elapsed (ms)",
+    "Fix Timestamp",
+    "Latitude",
+    "Longitude",
+    "Accuracy (m)",
+    "Altitude (m)",
+    "Altitude Accuracy (m)",
+    "Heading (deg)",
+    "Speed (m/s)",
+  ];
+  const rows: string[][] = [];
+  for (const attempt of attempts) {
+    if (!attempt.completed) continue;
+    if (!attempt.gpsTrack || attempt.gpsTrack.length === 0) continue;
+    const trail = attemptTrail(attempt);
+    const startDateTime = new Date(attempt.startTime).toISOString();
+    for (const fix of attempt.gpsTrack) {
+      rows.push([
+        attempt.id,
+        trail.name,
+        startDateTime,
+        String(fix.t),
+        new Date(attempt.startTime + fix.t).toISOString(),
+        fix.lat.toFixed(7),
+        fix.lng.toFixed(7),
+        fix.acc.toFixed(1),
+        fix.alt != null ? fix.alt.toFixed(2) : "",
+        fix.altAcc != null ? fix.altAcc.toFixed(2) : "",
+        fix.heading != null ? fix.heading.toFixed(1) : "",
+        fix.speed != null ? fix.speed.toFixed(2) : "",
+      ]);
+    }
+  }
+  if (rows.length === 0) return;
+
+  const escape = (cell: string) => `"${cell.replace(/"/g, '""')}"`;
+  const csvContent = [
+    headers.map(escape).join(","),
+    ...rows.map((row) => row.map(escape).join(",")),
+  ].join("\n");
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `hikes-gps-track-${new Date().toISOString().split("T")[0]}.csv`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/src/lib/trails.ts
+++ b/src/lib/trails.ts
@@ -197,18 +197,92 @@ export function getProgressForMarker(trail: Trail, lastTapped: number): MarkerPr
   };
 }
 
+/**
+ * Project (lat, lng) onto the trail polyline by finding the nearest *segment*
+ * (not just the nearest vertex) and dropping a perpendicular foot. Returns the
+ * foot's along-trail progress + interpolated elevation.
+ *
+ * Uses a local equirectangular projection at the trail's mid-latitude so the
+ * 2D dot-product math is in approximate metres. For the lengths involved
+ * (≤3 km, ≤1 km lat/lng span) the flat-earth error is well under a metre.
+ *
+ * Compared to the previous nearest-vertex snap, segment projection eliminates
+ * the discrete jumps as the runner crosses each vertex and gives a smooth,
+ * monotonic along-trail progress signal — which the auto-tracking approach
+ * detector then uses for distance-to-next-marker calculations.
+ */
 export function snapToMasterTrail(trail: Trail, lat: number, lng: number): MarkerProgress {
+  const route = trail.route;
+  if (route.length === 0) {
+    return {
+      marker: -1,
+      distanceM: 0,
+      distancePct: 0,
+      elevation: trail.baseElevation,
+      elevationPct: 0,
+    };
+  }
+
+  // Equirectangular metre conversion at the trail's centre latitude.
+  const midLat = (trail.geoBounds.minLat + trail.geoBounds.maxLat) / 2;
+  const cosMid = Math.cos((midLat * Math.PI) / 180);
+  const M_PER_DEG_LAT = 111320;
+  const M_PER_DEG_LNG = 111320 * cosMid;
+  const px = lng * M_PER_DEG_LNG;
+  const py = lat * M_PER_DEG_LAT;
+
   let bestIdx = 0;
-  let bestD = Infinity;
-  for (let i = 0; i < trail.route.length; i++) {
-    const d = haversineM(lat, lng, trail.route[i].lat, trail.route[i].lng);
-    if (d < bestD) {
-      bestD = d;
+  let bestT = 0;
+  let bestD2 = Infinity;
+
+  for (let i = 0; i < route.length - 1; i++) {
+    const a = route[i];
+    const b = route[i + 1];
+    const ax = a.lng * M_PER_DEG_LNG;
+    const ay = a.lat * M_PER_DEG_LAT;
+    const bx = b.lng * M_PER_DEG_LNG;
+    const by = b.lat * M_PER_DEG_LAT;
+    const dx = bx - ax;
+    const dy = by - ay;
+    const segLen2 = dx * dx + dy * dy;
+    let t = 0;
+    if (segLen2 > 0) {
+      t = ((px - ax) * dx + (py - ay) * dy) / segLen2;
+      if (t < 0) t = 0;
+      else if (t > 1) t = 1;
+    }
+    const fx = ax + t * dx;
+    const fy = ay + t * dy;
+    const ex = px - fx;
+    const ey = py - fy;
+    const d2 = ex * ex + ey * ey;
+    if (d2 < bestD2) {
+      bestD2 = d2;
       bestIdx = i;
+      bestT = t;
     }
   }
-  const distanceM = trail.masterCumM[bestIdx];
-  const elevation = trail.route[bestIdx].ele;
+
+  // Single-vertex polyline edge case (no segments) — fall back to the lone vertex.
+  if (route.length === 1) {
+    const distanceM = trail.masterCumM[0];
+    const elevation = route[0].ele;
+    return {
+      marker: -1,
+      distanceM,
+      distancePct: trail.totalDistanceM > 0 ? (distanceM / trail.totalDistanceM) * 100 : 0,
+      elevation,
+      elevationPct: trail.elevationGain > 0 ? ((elevation - trail.baseElevation) / trail.elevationGain) * 100 : 0,
+    };
+  }
+
+  const segStart = trail.masterCumM[bestIdx];
+  const segEnd = trail.masterCumM[bestIdx + 1];
+  const distanceM = segStart + bestT * (segEnd - segStart);
+  const elevA = route[bestIdx].ele;
+  const elevB = route[bestIdx + 1].ele;
+  const elevation = elevA + bestT * (elevB - elevA);
+
   return {
     marker: -1,
     distanceM,
@@ -216,6 +290,28 @@ export function snapToMasterTrail(trail: Trail, lat: number, lng: number): Marke
     elevation,
     elevationPct: trail.elevationGain > 0 ? ((elevation - trail.baseElevation) / trail.elevationGain) * 100 : 0,
   };
+}
+
+/**
+ * Signed along-trail distance from a GPS fix to a target marker, in metres.
+ * Positive = the runner hasn't reached the marker yet (marker is ahead).
+ * Negative = the runner has passed the marker (marker is behind).
+ *
+ * Computed as `marker.distanceM - snap(fix).distanceM`. Because snap projects
+ * onto the trail, this value is monotone in along-trail position regardless of
+ * cross-trail GPS noise — much better than great-circle straight-line distance
+ * for approach detection on a noisy trail.
+ */
+export function alongTrailDistanceToMarker(
+  trail: Trail,
+  fixLat: number,
+  fixLng: number,
+  markerNum: number,
+): number | null {
+  const rec = trail.markersByNum.get(markerNum);
+  if (!rec) return null;
+  const snapped = snapToMasterTrail(trail, fixLat, fixLng);
+  return rec.distanceM - snapped.distanceM;
 }
 
 export function interpolateMarkerProgress(trail: Trail, marker: number): MarkerProgress {


### PR DESCRIPTION
## Summary

Cuts cross-trail GPS noise out of the auto-marker approach detector and captures the full GPS fix stream for offline analysis.

## What changed

### `snapToMasterTrail` is now segment-based, not vertex-based

Previously the snap picked the nearest *vertex* of the trail polyline. With the Grind polyline averaging ~15m between vertices, that discretised progress in 15m steps and pumped noise back into the approach detector. New version drops a perpendicular foot onto the nearest *segment* via local equirectangular projection at the trail's centre latitude — smooth, monotonic along-trail progress.

### Approach detector uses along-trail signed distance

New `alongTrailDistanceToMarker(trail, lat, lng, marker)` helper returns \`markerProgress.distanceM - snap(fix).distanceM\`. ActiveHike's approach radius test now uses \`|alongTrailDist|\` instead of great-circle haversine, so cross-trail GPS noise no longer inflates the apparent distance to a marker.

Tunables retuned for the new metric:
- \`GPS_ACCURACY_MAX_M\`: 30 → 50
- \`APPROACH_RADIUS_ACCURACY_FACTOR\`: 1.5 → 1.0

### Raw GPS track captured on every hike

- Extended \`GpsPosition\` (and \`useGps\`) with \`heading\` + \`speed\`.
- New \`HikeAttempt.gpsTrack: GpsFix[]\` (throttled ~1Hz).
- Each fix: \`t, lat, lng, acc, alt, altAcc, heading, speed\`.
- Persisted via \`saveActiveHike\` mid-hike so a crash doesn't lose the trace.
- \`exportGpsTracksAsCsv()\` + a "GPS track CSV" button in HikeHistory next to the splits export. Disables when no visible hikes have a track.

### Dev simulator updated

\`gps-simulator.ts\` emits synthetic heading (atan2 to next route vertex) + the configured speed on each fake fix so the new gpsTrack pipeline sees realistic non-null values during sim runs.

## Why

Previous behaviour on a noisy trail (Grind under canopy):
- Raw GPS accuracy 15-50m+
- 2D haversine to next marker stayed elevated even when walking past it
- Approach radius \`max(15m, accuracy × 1.5)\` rarely engaged
- Auto-tracking force-fell to Manual mode for most of the hike

After Tier 1: along-trail residual stays small even with 50m raw accuracy because the cross-trail component projects out. Auto stays armed; markers commit on approach.

## Test plan

- [x] \`npm run build\` and \`npx tsc --noEmit\` pass
- [x] Sim test on Grind at 5× (3 m/s): 4 markers auto-committed in 170s — wasn't possible pre-Tier-1 with the same sim speed
- [x] gpsTrack populated with all fields (262 fixes over 263s of sim time)
- [ ] Field test on next BCMC + Grind hikes; export GPS track CSV; verify altitude is barometric on iOS

## Known limitations

- At 60× sim speed, position jumps 18m/tick exceed the 15m min approach radius — markers blow past zones without entering. Sim artifact, not a real-world concern (humans don't move at 36 m/s).
- iOS Safari may return null \`altitude\` if the device lacks a barometer or GPS lock — gpsTrack records \`null\` in that case. Verify on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)