### PR TITLE
Add scenario-driven integration test harness for ActiveHike

### DIFF
--- a/src/lib/scenario-player.ts
+++ b/src/lib/scenario-player.ts
@@ -1,0 +1,105 @@
+// Test-only GPS scenario player. Like gps-simulator, monkey-patches
+// navigator.geolocation.{watchPosition,clearWatch}, but instead of computing
+// fixes from trail geometry + metersPerSecond, it emits a fixed sequence of
+// pre-recorded fixes whose tMs is measured from install time. Drive with
+// vi.advanceTimersByTime() in tests.
+
+export interface ScenarioFix {
+  /** Elapsed ms from installScenario() call. */
+  tMs: number;
+  lat: number;
+  lng: number;
+  ele: number;
+  /** Accuracy in metres. ActiveHike forces Manual mode when accuracy > 30m. */
+  accuracy: number;
+}
+
+interface PlayerState {
+  fixes: ScenarioFix[];
+  nextIdx: number;
+  startMs: number;
+  watchers: Map<number, { ok: PositionCallback; err?: PositionErrorCallback | null }>;
+  nextWatchId: number;
+  timer: ReturnType<typeof setInterval> | null;
+  origWatch: typeof navigator.geolocation.watchPosition;
+  origClear: typeof navigator.geolocation.clearWatch;
+}
+
+let state: PlayerState | null = null;
+
+function makeGeolocationPosition(fix: ScenarioFix): GeolocationPosition {
+  const ts = Date.now();
+  const coords: GeolocationCoordinates = {
+    latitude: fix.lat,
+    longitude: fix.lng,
+    altitude: fix.ele,
+    accuracy: fix.accuracy,
+    altitudeAccuracy: 1,
+    heading: null,
+    speed: null,
+    toJSON() { return { ...this }; },
+  } as GeolocationCoordinates;
+  return {
+    coords,
+    timestamp: ts,
+    toJSON() { return { coords, timestamp: ts }; },
+  } as GeolocationPosition;
+}
+
+function tick() {
+  if (!state) return;
+  const elapsed = Date.now() - state.startMs;
+  while (state.nextIdx < state.fixes.length && state.fixes[state.nextIdx].tMs <= elapsed) {
+    const fix = state.fixes[state.nextIdx++];
+    const pos = makeGeolocationPosition(fix);
+    for (const { ok } of state.watchers.values()) {
+      try { ok(pos); } catch { /* ignore */ }
+    }
+  }
+}
+
+export function installScenario(fixes: ScenarioFix[], opts?: { tickMs?: number }): void {
+  if (state) uninstallScenario();
+  const tickMs = opts?.tickMs ?? 100;
+  const origWatch = navigator.geolocation.watchPosition.bind(navigator.geolocation);
+  const origClear = navigator.geolocation.clearWatch.bind(navigator.geolocation);
+  state = {
+    fixes: [...fixes].sort((a, b) => a.tMs - b.tMs),
+    nextIdx: 0,
+    startMs: Date.now(),
+    watchers: new Map(),
+    nextWatchId: 1,
+    timer: null,
+    origWatch,
+    origClear,
+  };
+
+  const fakeWatch = (success: PositionCallback, error?: PositionErrorCallback | null): number => {
+    if (!state) return -1;
+    const id = state.nextWatchId++;
+    state.watchers.set(id, { ok: success, err: error });
+    return id;
+  };
+
+  const fakeClear = (id: number) => {
+    if (!state) return;
+    state.watchers.delete(id);
+  };
+
+  Object.defineProperty(navigator.geolocation, "watchPosition", { configurable: true, value: fakeWatch });
+  Object.defineProperty(navigator.geolocation, "clearWatch", { configurable: true, value: fakeClear });
+
+  state.timer = setInterval(tick, tickMs);
+}
+
+export function uninstallScenario(): void {
+  if (!state) return;
+  if (state.timer) clearInterval(state.timer);
+  Object.defineProperty(navigator.geolocation, "watchPosition", { configurable: true, value: state.origWatch });
+  Object.defineProperty(navigator.geolocation, "clearWatch", { configurable: true, value: state.origClear });
+  state = null;
+}
+
+export function isScenarioActive(): boolean {
+  return state !== null;
+}

--- a/src/test/active-hike.scenario.test.tsx
+++ b/src/test/active-hike.scenario.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * ActiveHike scenario integration test.
+ *
+ * Mounts <ActiveHike/>, monkey-patches navigator.geolocation via scenario-player
+ * to emit a pre-recorded sequence of GPS fixes, fast-forwards vi.useFakeTimers,
+ * and asserts the auto-tracker logged the expected markers — all in milliseconds.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import ActiveHike from "@/components/ActiveHike";
+import { BCMC_TRAIL } from "@/lib/trails";
+import { installScenario, uninstallScenario } from "@/lib/scenario-player";
+import { loadActiveHike } from "@/lib/hike-store";
+import { happyPathBcmc } from "./fixtures/scenarios";
+
+const TICK_MS = 100;
+
+/** Step the fake clock forward in TICK_MS chunks so each scenario fix is
+ *  observed by React separately (a single coarse advance would coalesce
+ *  setPosition calls and the auto-tracker would miss intermediate fixes). */
+function advanceInChunks(totalMs: number) {
+  const steps = Math.ceil(totalMs / TICK_MS);
+  for (let i = 0; i < steps; i++) {
+    act(() => {
+      vi.advanceTimersByTime(TICK_MS);
+    });
+  }
+}
+
+describe("ActiveHike — happy-path BCMC scenario", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers({ now: new Date("2026-05-03T08:00:00Z") });
+  });
+
+  afterEach(() => {
+    uninstallScenario();
+    vi.useRealTimers();
+  });
+
+  it("auto-logs all 7 markers via the auto-tracker", () => {
+    installScenario(happyPathBcmc.fixes, { tickMs: TICK_MS });
+
+    render(<ActiveHike onFinish={() => {}} trail={BCMC_TRAIL} />);
+
+    fireEvent.click(screen.getByText("In Parking Lot"));
+    fireEvent.click(screen.getByText("START"));
+
+    const lastTMs = happyPathBcmc.fixes[happyPathBcmc.fixes.length - 1].tMs;
+    advanceInChunks(lastTMs + 2_000);
+
+    const active = loadActiveHike();
+    expect(active).not.toBeNull();
+    const splits = active!.splits;
+
+    // Auto-tracker should have committed splits for markers 1..7 in order.
+    const autoMarkers = splits.filter((s) => !s.skipped).map((s) => s.marker);
+    for (const m of happyPathBcmc.expected!.markersHit!) {
+      expect(autoMarkers).toContain(m);
+    }
+    // No skips expected on the happy path.
+    expect(splits.filter((s) => s.skipped)).toHaveLength(0);
+  });
+});

--- a/src/test/fixtures/scenarios.ts
+++ b/src/test/fixtures/scenarios.ts
@@ -1,0 +1,76 @@
+// Scenario fixtures for ActiveHike integration tests. Each scenario is a
+// time-stamped sequence of GPS fixes plus the expected outcome. Drive with
+// installScenario() + vi.advanceTimersByTime().
+
+import type { ScenarioFix } from "@/lib/scenario-player";
+import { BCMC_RAW_MARKERS } from "@/lib/trail-data-bcmc";
+import type { TrailId } from "@/lib/trails";
+
+export interface Scenario {
+  name: string;
+  trail: TrailId;
+  fixes: ScenarioFix[];
+  expected?: {
+    markersHit?: number[];
+    skipped?: number[];
+    totalTimeMs?: number;
+  };
+}
+
+const ACCURATE = 5;
+const INACCURATE = 60;
+
+/** Build fixes that walk through markers `[from..to]` in order, dwelling on each
+ *  long enough for the auto-tracker (approach in zone → exit) to commit a split.
+ *  Cadence: 1 fix/sec; 8s between markers (4s approaching, 1s on, 3s leaving). */
+function fixesThroughMarkers(markers: number[], startMs = 0, accuracy = ACCURATE): ScenarioFix[] {
+  const out: ScenarioFix[] = [];
+  let t = startMs;
+  for (let i = 0; i < markers.length; i++) {
+    const m = BCMC_RAW_MARKERS.find((r) => r.marker === markers[i])!;
+    const next = i + 1 < markers.length
+      ? BCMC_RAW_MARKERS.find((r) => r.marker === markers[i + 1])!
+      : null;
+    // 4 fixes approaching the marker (offset slightly before)
+    for (let k = 4; k >= 1; k--) {
+      out.push({
+        tMs: t,
+        lat: m.lat - 0.00002 * k,
+        lng: m.lng + 0.00002 * k,
+        ele: m.elevation - k,
+        accuracy,
+      });
+      t += 1000;
+    }
+    // ON the marker
+    out.push({ tMs: t, lat: m.lat, lng: m.lng, ele: m.elevation, accuracy });
+    t += 1000;
+    // 3 fixes leaving toward the next marker — needed so distance is *increasing*
+    // and the auto-tracker commits the split.
+    for (let k = 1; k <= 3; k++) {
+      const dlat = next ? (next.lat - m.lat) * (k / 4) : 0.00005 * k;
+      const dlng = next ? (next.lng - m.lng) * (k / 4) : 0.00005 * k;
+      out.push({
+        tMs: t,
+        lat: m.lat + dlat,
+        lng: m.lng + dlng,
+        ele: m.elevation + k,
+        accuracy,
+      });
+      t += 1000;
+    }
+  }
+  return out;
+}
+
+export const happyPathBcmc: Scenario = {
+  name: "happy-path-bcmc",
+  trail: "bcmc",
+  fixes: fixesThroughMarkers([1, 2, 3, 4, 5, 6, 7]),
+  expected: {
+    markersHit: [1, 2, 3, 4, 5, 6, 7],
+  },
+};
+
+// Additional scenarios (glitchy GPS, missed-marker, restart-mid-hike) follow the
+// same pattern. Shipping the happy path first to validate the harness.

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,56 @@
 import "@testing-library/jest-dom";
 
+// The host node binary preloads a stub `localStorage` global without the
+// Storage prototype methods (clear/getItem/setItem/removeItem). jsdom's own
+// Storage gets shadowed, so install a working shim before any test code runs.
+if (typeof localStorage === "undefined" || typeof (localStorage as { clear?: unknown }).clear !== "function") {
+  const store = new Map<string, string>();
+  const shim = {
+    get length() { return store.size; },
+    clear: () => { store.clear(); },
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)); },
+    removeItem: (k: string) => { store.delete(k); },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+  };
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: shim });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: shim });
+}
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  class ResizeObserverShim {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, "ResizeObserver", { configurable: true, value: ResizeObserverShim });
+}
+
+if (!("geolocation" in navigator)) {
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: {
+      watchPosition: () => 0,
+      clearWatch: () => {},
+      getCurrentPosition: () => {},
+    },
+  });
+}
+
+if (!("wakeLock" in navigator)) {
+  Object.defineProperty(navigator, "wakeLock", {
+    configurable: true,
+    value: {
+      request: async () => ({
+        released: false,
+        release: async () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    },
+  });
+}
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
## Summary

- New scenario player monkey-patches \`navigator.geolocation\` to emit a pre-recorded sequence of GPS fixes on a fake-timer-driven interval. Combined with \`vi.useFakeTimers\`, this lets tests fully control wall clock + GPS feed and run a full hike in milliseconds.
- First integration test mounts \`<ActiveHike>\`, advances the fake clock, and asserts the auto-tracker committed all 7 expected marker splits (~280ms runtime).
- Adds jsdom shims for the test environment. The host node binary preloads a \`localStorage\` global without Storage methods, which was silently breaking 11 pre-existing tests in \`simulated-hike.test.ts\`; those now pass.

## Why this approach instead of a DI framework

The repo already has a GPS injection seam (\`gps-simulator.ts\` monkey-patches \`navigator.geolocation\`), and \`vi.useFakeTimers\` + \`vi.setSystemTime\` already fake every \`Date.now()\` / \`setInterval\` / \`setTimeout\` call globally. So the 15 time-call-sites in [ActiveHike.tsx](src/components/ActiveHike.tsx) need no changes — no \`Clock\` context, no \`useClock()\` hook, no DI container. The whole change is additive: ~300 LOC across 4 files, zero changes to production components.

## Files

- \`src/lib/scenario-player.ts\` — standalone, separate from \`gps-simulator.ts\` (which keeps its real-time \`metersPerSecond\` replay for SimPanel dev mode).
- \`src/test/fixtures/scenarios.ts\` — \`Scenario\` type + \`happyPathBcmc\` (56 fixes through markers 1–7). Adding glitchy-GPS / missed-marker / restart-mid-hike scenarios is now a fixture-only change.
- \`src/test/active-hike.scenario.test.tsx\` — first integration test.
- \`src/test/setup.ts\` — shims for localStorage, ResizeObserver, \`navigator.geolocation\`, \`navigator.wakeLock\`.

## Test plan

- [x] \`npx vitest run\` — 24/24 pass (was 11/23 before this branch on this machine; the \`localStorage\` shim fixes the 11 pre-existing failures)
- [x] \`npx tsc --noEmit\` clean
- [ ] Reviewer: spot-check that SimPanel's real-time replay still works in \`npm run dev\` — \`gps-simulator.ts\` was not modified, so behavior should be unchanged
- [ ] Reviewer: confirm the scenario fixture cadence (1s/fix, 8 fixes/marker) matches expectations of the auto-tracker's \`EXIT_INCREASING_FIXES\` threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)