### PR TITLE
Audio feedback during hikes (TTS + chime)

### DIFF
--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -33,6 +33,8 @@ import {
 } from "@/lib/trails";
 import TrailProgress from "@/components/TrailProgress";
 import MapBackground from "@/components/MapBackground";
+import { speak, chime, unlockAudio, getAudioEnabled, setAudioEnabled } from "@/lib/audio";
+import { Volume2, VolumeX } from "lucide-react";
 
 interface ActiveHikeProps {
   onFinish: () => void;
@@ -105,6 +107,8 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
   const approachRef = useRef<ApproachState | null>(null);
   const [approachInZone, setApproachInZone] = useState(false);
   const [approachPassing, setApproachPassing] = useState(false);
+  const [audioOn, setAudioOnState] = useState<boolean>(() => getAudioEnabled());
+  const lastAnnouncedMarkerRef = useRef<number | null>(null);
 
   // Notify parent of active state
   useEffect(() => { onActiveChange?.(isRunning); }, [isRunning, onActiveChange]);
@@ -265,9 +269,26 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
       approachRef.current = null;
       setApproachInZone(false);
       setApproachPassing(false);
+      if (!split.skipped) chime("logged");
     },
     []
   );
+
+  // Audio: announce when entering an approach zone for a new marker.
+  // In auto mode: "Approaching marker N". In manual mode: "Tap at marker N"
+  // (helpful for the calibration hike where every marker needs a manual tap).
+  useEffect(() => {
+    if (!isRunning) return;
+    if (!approachInZone) {
+      if (lastAnnouncedMarkerRef.current !== null && lastAnnouncedMarkerRef.current !== nextMarker) {
+        lastAnnouncedMarkerRef.current = null;
+      }
+      return;
+    }
+    if (lastAnnouncedMarkerRef.current === nextMarker) return;
+    lastAnnouncedMarkerRef.current = nextMarker;
+    speak(mode === "manual" ? `Tap at marker ${nextMarker}` : `Approaching marker ${nextMarker}`);
+  }, [approachInZone, nextMarker, mode, isRunning]);
 
   // Auto-tracking: on each GPS fix, maintain closest-approach for the next marker
   // and commit when the user exits the approach zone.
@@ -409,6 +430,7 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
   }, [position, gpsAccurate, nextMarker, isRunning, attempt, userForcedManual, foregroundCount]);
 
   const handleStart = useCallback(() => {
+    unlockAudio(); // iOS gesture-unlock so later TTS/chime can play
     const a = createAttempt(selectedTrail.id);
     setAttempt(a);
     saveActiveHike(a);
@@ -571,17 +593,36 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
           </div>
         )}
 
-        {onHelpOpen && (
+        <div className="flex items-center gap-2">
+          {onHelpOpen && (
+            <button
+              onClick={onHelpOpen}
+              className="btn-bevel flex items-center gap-3 pl-3 pr-5 py-3 rounded-2xl border border-border text-sm font-medium text-foreground touch-manipulation select-none"
+            >
+              <span className="w-7 h-7 rounded-lg flex items-center justify-center bg-primary/10 border border-primary/25 text-primary">
+                <HelpCircle className="w-4 h-4" />
+              </span>
+              Instructions
+            </button>
+          )}
           <button
-            onClick={onHelpOpen}
+            onClick={() => {
+              const next = !audioOn;
+              setAudioEnabled(next);
+              setAudioOnState(next);
+              if (next) unlockAudio();
+            }}
+            aria-pressed={audioOn}
+            aria-label={audioOn ? "Audio feedback on" : "Audio feedback off"}
+            title={audioOn ? "Audio feedback on" : "Audio feedback off"}
             className="btn-bevel flex items-center gap-3 pl-3 pr-5 py-3 rounded-2xl border border-border text-sm font-medium text-foreground touch-manipulation select-none"
           >
-            <span className="w-7 h-7 rounded-lg flex items-center justify-center bg-primary/10 border border-primary/25 text-primary">
-              <HelpCircle className="w-4 h-4" />
+            <span className={`w-7 h-7 rounded-lg flex items-center justify-center border ${audioOn ? "bg-primary/10 border-primary/25 text-primary" : "bg-muted border-border text-muted-foreground"}`}>
+              {audioOn ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
             </span>
-            Instructions
+            Audio
           </button>
-        )}
+        </div>
 
         {trailSwitch}
 

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,0 +1,92 @@
+// Audio feedback for hikes — TTS announcements + confirmation chime.
+//
+// iOS quirks worth knowing:
+//   - speechSynthesis and AudioContext both need a user-gesture unlock before
+//     they'll play. Call `unlockAudio()` from a tap handler (Start button).
+//   - When the screen locks or the page is hidden, audio session is suspended.
+//     Wake Lock keeps the screen on, which keeps audio working.
+//   - iOS will briefly duck other audio (Spotify) to play a TTS utterance, then
+//     restore. No extra config required.
+
+const ENABLED_KEY = "audioEnabled";
+
+export function getAudioEnabled(): boolean {
+  const v = localStorage.getItem(ENABLED_KEY);
+  return v === null ? true : v === "true";
+}
+
+export function setAudioEnabled(enabled: boolean): void {
+  localStorage.setItem(ENABLED_KEY, String(enabled));
+  if (!enabled) {
+    try { window.speechSynthesis?.cancel(); } catch { /* ignore */ }
+  }
+}
+
+let audioCtx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (audioCtx) return audioCtx;
+  const Ctor = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  audioCtx = new Ctor();
+  return audioCtx;
+}
+
+/** Call from a user-gesture handler so iOS will allow later programmatic playback. */
+export function unlockAudio(): void {
+  const ctx = getCtx();
+  if (ctx && ctx.state === "suspended") {
+    void ctx.resume().catch(() => { /* ignore */ });
+  }
+  // Prime speechSynthesis with an empty utterance so subsequent calls are allowed.
+  try {
+    const u = new SpeechSynthesisUtterance("");
+    u.volume = 0;
+    window.speechSynthesis?.speak(u);
+  } catch { /* ignore */ }
+}
+
+export function speak(text: string): void {
+  if (!getAudioEnabled()) return;
+  const synth = window.speechSynthesis;
+  if (!synth) return;
+  try {
+    synth.cancel(); // drop any queued utterance — fresher info wins
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1.05;
+    u.pitch = 1.0;
+    u.volume = 1.0;
+    synth.speak(u);
+  } catch { /* ignore */ }
+}
+
+/** Short confirmation chime. type "logged" = rising two-tone; "approach" = single soft beep. */
+export function chime(type: "logged" | "approach" = "logged"): void {
+  if (!getAudioEnabled()) return;
+  const ctx = getCtx();
+  if (!ctx) return;
+  if (ctx.state === "suspended") void ctx.resume().catch(() => { /* ignore */ });
+
+  const now = ctx.currentTime;
+  const gain = ctx.createGain();
+  gain.connect(ctx.destination);
+  gain.gain.setValueAtTime(0.0001, now);
+
+  const playTone = (freq: number, start: number, dur: number, peak: number) => {
+    const osc = ctx.createOscillator();
+    osc.type = "triangle";
+    osc.frequency.setValueAtTime(freq, now + start);
+    osc.connect(gain);
+    osc.start(now + start);
+    osc.stop(now + start + dur);
+    gain.gain.exponentialRampToValueAtTime(peak, now + start + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + start + dur);
+  };
+
+  if (type === "logged") {
+    playTone(660, 0, 0.12, 0.25);
+    playTone(880, 0.12, 0.16, 0.25);
+  } else {
+    playTone(520, 0, 0.18, 0.18);
+  }
+}


### PR DESCRIPTION
## Summary
Adds audio feedback so the user can keep their phone in a pack pocket and trust that the app is tracking — silence = something's wrong (e.g., wake lock dropped, screen locked).

- New `src/lib/audio.ts` — `speak()` (speechSynthesis), `chime()` (Web Audio triangle tones), `unlockAudio()` for iOS gesture-unlock, on/off flag persisted in localStorage.
- ActiveHike integration:
  - On entering an approach zone: TTS announces \"Approaching marker N\" (auto mode) or \"Tap at marker N\" (manual mode — useful for the upcoming Grind calibration hike).
  - On every non-skipped commit: short two-tone chime.
  - Audio unlocks on the Start button tap.
- Pre-start screen: new \"Audio\" toggle next to Instructions, default on.

## iOS notes
Wake Lock is already requested during a hike, so the screen stays on and the audio session stays alive. If the user hardware-locks the phone, wake lock drops and audio stops — that's the intended failure signal. iOS will briefly duck Spotify to play TTS, then restore.

## Test plan
- [x] `bunx vitest run` — 24/24 pass
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual on iPhone: toggle Audio on → start hike → hear chime on first auto marker
- [ ] Manual: switch to Manual mode near a known-position marker → hear \"Tap at marker N\"
- [ ] Manual: toggle Audio off → start hike → silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)