### PR TITLE
History: stop clipping kebab menu on collapsed rows

### DIFF
--- a/src/components/HikeHistory.tsx
+++ b/src/components/HikeHistory.tsx
@@ -279,7 +279,7 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
           return (
             <div
               key={a.id}
-              className={`bg-card border rounded-2xl overflow-hidden transition-colors ${
+              className={`bg-card border rounded-2xl transition-colors ${
                 isSelected ? "border-primary/60 shadow-[inset_0_0_0_1px_hsla(145,60%,45%,0.2)]" : "border-border"
               }`}
               style={isSelected ? { background: "linear-gradient(180deg, hsla(145,60%,45%,0.06), hsl(0 0% 4%))" } : undefined}


### PR DESCRIPTION
## Summary
The hike row card had \`overflow-hidden\`, which clipped the absolutely-positioned kebab menu whenever the row wasn't expanded enough to contain it (i.e., always on collapsed rows, and on hikes with no logged markers). Drop the rule — the expanded section doesn't actually need clipping.

## Test plan
- [x] \`bunx vitest run\` — 24/24 pass
- [x] \`bunx tsc --noEmit\` — clean
- [ ] Manual: kebab on collapsed row opens fully, no clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)