### PR TITLE
Excel-friendly hike CSV with trail distance per marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Track split times at numbered trail markers. Tap button as you pass each marker.
 - All hikes saved to browser localStorage. No account needed.
 - Compare up to 3 hikes side by side.
 - See best and average times per segment across all hikes.
-- Export any hike to CSV (marker, time, coords, accuracy, logging mode, tags).
+- Export any hike to CSV (marker, local time, lat/lng/alt, accuracy, cumulative + segment trail distance, logging mode, tags). Excel-friendly columns; rows sorted oldest hike first, markers ascending.
 
 ## Marker button — what it shows and why
 

--- a/src/lib/hike-store.ts
+++ b/src/lib/hike-store.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TRAIL_ID, isTrailId, getTrail, type TrailId } from "./trails";
+import { DEFAULT_TRAIL_ID, isTrailId, getTrail, interpolateMarkerProgress, type TrailId } from "./trails";
 
 // Legacy BCMC-only constants kept for any remaining call site that hasn't been migrated to
 // per-trail values yet. New code should read these off the active Trail.
@@ -39,7 +39,7 @@ export interface HikeTag {
   timestamp: number; // ms since epoch
   elapsed: number; // ms since hike start
   text: string;
-  coords?: GpsCoord; // saved but not exported / not shown in UI
+  coords?: GpsCoord; // GPS where the tag was dropped; exported in CSV, not shown in UI
 }
 
 /**
@@ -260,48 +260,99 @@ export function formatSplitDiff(current: number, best?: number): { text: string;
   return { text: `${sign}${formatDuration(Math.abs(diff))}`, positive: diff <= 0 };
 }
 
+/**
+ * Local timestamp in a format Excel parses natively as a date-time:
+ * `YYYY-MM-DD HH:MM:SS` (no `T`, no `Z`), in the device's local timezone.
+ * Plain ISO with a `Z` suffix imports as text in many Excel locales, so we
+ * build the string from local calendar fields instead.
+ */
+function formatExcelLocal(ms: number): string {
+  const d = new Date(ms);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
+/**
+ * Canonical cumulative along-trail distance (m) for a marker number. Known
+ * markers use their dataset distance; markers missing from the dataset use the
+ * split's saved progress override, else linear interpolation between the
+ * nearest known neighbours. Start = 0, finish = full trail length.
+ */
+function cumulativeDistanceForMarker(
+  trail: ReturnType<typeof attemptTrail>,
+  marker: number,
+  override?: Split["progressOverride"],
+): number {
+  if (marker <= 0) return 0;
+  if (marker >= trail.finishMarker) return trail.totalDistanceM;
+  const rec = trail.markersByNum.get(marker);
+  if (rec) return rec.distanceM;
+  if (override) return override.distanceM;
+  return interpolateMarkerProgress(trail, marker).distanceM;
+}
+
 export function exportHikesAsCsv(attempts: HikeAttempt[]): void {
   const headers = [
     "Hike ID",
     "Trail",
-    "Hike Start Date-Time",
+    "Hike Start (local)",
     "Trail Marker Number",
     "Trail Number Forgotten",
-    "Trail Marker Timestamp",
-    "Trail Marker GPS Position",
-    "Trail Marker GPS Accuracy (m)",
+    "Trail Marker Timestamp (local)",
+    "Latitude",
+    "Longitude",
+    "Altitude (m)",
+    "GPS Accuracy (m)",
+    "Cumulative Trail Distance (m)",
+    "Segment Distance (m)",
     "Logging Mode",
   ];
 
-  const formatCoord = (c?: GpsCoord): { pos: string; acc: string } => {
-    if (!c) return { pos: "", acc: "" };
-    const altStr = c.altitude != null ? `,${c.altitude.toFixed(1)}` : "";
+  // Lat / Lng / Alt as separate numeric columns (no packed "lat,lng,alt" cell)
+  // so Excel imports each as a real number.
+  const coordCols = (c?: GpsCoord): { lat: string; lng: string; alt: string; acc: string } => {
+    if (!c) return { lat: "", lng: "", alt: "", acc: "" };
     return {
-      pos: `${c.latitude.toFixed(7)},${c.longitude.toFixed(7)}${altStr}`,
+      lat: c.latitude.toFixed(7),
+      lng: c.longitude.toFixed(7),
+      alt: c.altitude != null ? c.altitude.toFixed(1) : "",
       acc: c.accuracy != null ? c.accuracy.toFixed(1) : "",
     };
   };
 
   const rows: string[][] = [];
-  for (const attempt of attempts) {
+  // Req 4: oldest hike first.
+  const ordered = [...attempts].sort((a, b) => a.startTime - b.startTime);
+  for (const attempt of ordered) {
     if (!attempt.completed) continue;
     const trail = attemptTrail(attempt);
-    const startDateTime = new Date(attempt.startTime).toISOString();
-    const startGps = formatCoord(attempt.startCoords);
+    const startLocal = formatExcelLocal(attempt.startTime);
+
+    // Segment distance accumulates from the last *captured* marker. Missing /
+    // forgotten markers leave their own segment blank so the next captured
+    // marker spans the whole gap — giving an honest distance for speed.
+    let lastCapturedCum = 0; // start line is the origin reference
+
     // Start row (marker 0)
+    const startGps = coordCols(attempt.startCoords);
     rows.push([
       attempt.id,
       trail.name,
-      startDateTime,
+      startLocal,
       "0",
-      "false",
-      startDateTime,
-      startGps.pos,
+      "FALSE",
+      startLocal,
+      startGps.lat,
+      startGps.lng,
+      startGps.alt,
       startGps.acc,
+      "0.0",
+      "",
       "",
     ]);
-    // Build a combined, time-ordered event stream of splits + tags so tags appear
-    // in chronological order next to the marker rows they sit between.
+
+    // Combined, time-ordered stream of splits + tags so tags appear in
+    // chronological order next to the marker rows they sit between.
     type Event =
       | { kind: "split"; at: number; split: Split }
       | { kind: "tag"; at: number; tag: HikeTag };
@@ -309,65 +360,76 @@ export function exportHikesAsCsv(attempts: HikeAttempt[]): void {
     for (const s of attempt.splits) events.push({ kind: "split", at: s.timestamp, split: s });
     for (const t of attempt.tags ?? []) events.push({ kind: "tag", at: t.timestamp, tag: t });
     events.sort((a, b) => a.at - b.at);
+
     for (const ev of events) {
       if (ev.kind === "tag") {
-        const tagGps = formatCoord(ev.tag.coords);
+        const tagGps = coordCols(ev.tag.coords);
         rows.push([
           attempt.id,
           trail.name,
-          startDateTime,
+          startLocal,
           `Tag: ${ev.tag.text}`,
-          "false",
-          new Date(ev.tag.timestamp).toISOString(),
-          tagGps.pos,
+          "FALSE",
+          formatExcelLocal(ev.tag.timestamp),
+          tagGps.lat,
+          tagGps.lng,
+          tagGps.alt,
           tagGps.acc,
+          "", // tags aren't trail markers — no distance
+          "",
           "",
         ]);
         continue;
       }
       const split = ev.split;
-      const markerTimestamp = new Date(split.timestamp).toISOString();
-      const forgotten = split.skipped ? "true" : "false";
-      let gpsPosition = "";
-      let gpsAccuracy = "";
-      if (split.coords) {
-        const { latitude, longitude, altitude } = split.coords;
-        const altStr = altitude != null ? `,${altitude.toFixed(1)}` : "";
-        gpsPosition = `${latitude.toFixed(7)},${longitude.toFixed(7)}${altStr}`;
-        if (split.coords.accuracy != null) {
-          gpsAccuracy = split.coords.accuracy.toFixed(1);
-        }
-      }
+      const gps = coordCols(split.coords);
+      const cum = cumulativeDistanceForMarker(trail, split.marker, split.progressOverride);
+      // Captured markers report a segment from the last captured marker and
+      // become the new reference; forgotten markers leave it blank.
+      const segment = split.skipped ? "" : (cum - lastCapturedCum).toFixed(1);
+      if (!split.skipped) lastCapturedCum = cum;
       rows.push([
         attempt.id,
         trail.name,
-        startDateTime,
+        startLocal,
         String(split.marker),
-        forgotten,
-        markerTimestamp,
-        gpsPosition,
-        gpsAccuracy,
+        split.skipped ? "TRUE" : "FALSE",
+        formatExcelLocal(split.timestamp),
+        gps.lat,
+        gps.lng,
+        gps.alt,
+        gps.acc,
+        cum.toFixed(1),
+        segment,
         split.mode ?? "",
       ]);
     }
+
     // Finish row (per-trail finish marker number)
     if (attempt.endTime) {
-      const endGps = formatCoord(attempt.endCoords);
+      const endGps = coordCols(attempt.endCoords);
+      const cum = trail.totalDistanceM;
       rows.push([
         attempt.id,
         trail.name,
-        startDateTime,
+        startLocal,
         String(trail.finishMarker),
-        "false",
-        new Date(attempt.endTime).toISOString(),
-        endGps.pos,
+        "FALSE",
+        formatExcelLocal(attempt.endTime),
+        endGps.lat,
+        endGps.lng,
+        endGps.alt,
         endGps.acc,
+        cum.toFixed(1),
+        (cum - lastCapturedCum).toFixed(1),
         "manual",
       ]);
     }
   }
 
-  const escape = (cell: string) => `"${cell.replace(/"/g, '""')}"`;
+  // Quote only cells that need it, so numbers and dates import typed (not as text).
+  const escape = (cell: string) =>
+    /[",\n]/.test(cell) ? `"${cell.replace(/"/g, '""')}"` : cell;
   const csvContent = [
     headers.map(escape).join(","),
     ...rows.map((row) => row.map(escape).join(",")),

--- a/src/test/export-csv.test.ts
+++ b/src/test/export-csv.test.ts
@@ -1,0 +1,125 @@
+/**
+ * exportHikesAsCsv tests
+ *
+ * Verifies the Excel-friendly hike export: separate lat/lng/alt columns, local
+ * date-time formatting, per-marker cumulative + segment trail distance (with
+ * forgotten markers accumulating into the next captured marker), and full
+ * chronological ordering (oldest hike first).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { exportHikesAsCsv, type HikeAttempt, type Split } from "@/lib/hike-store";
+import { getTrail } from "@/lib/trails";
+
+// Capture the CSV text handed to Blob instead of actually downloading it.
+let captured = "";
+beforeEach(() => {
+  captured = "";
+  vi.stubGlobal(
+    "Blob",
+    class {
+      constructor(parts: string[]) {
+        captured = parts.join("");
+      }
+    },
+  );
+  vi.stubGlobal("URL", { createObjectURL: () => "blob:x", revokeObjectURL: () => {} });
+  const link = { href: "", download: "", click: () => {} } as unknown as HTMLAnchorElement;
+  vi.spyOn(document, "createElement").mockReturnValue(link);
+  vi.spyOn(document.body, "appendChild").mockImplementation((n) => n);
+  vi.spyOn(document.body, "removeChild").mockImplementation((n) => n);
+});
+
+function rows(): string[][] {
+  return captured.split("\n").map((line) => line.split(","));
+}
+
+const grind = getTrail("grind");
+const m = (n: number) => grind.markersByNum.get(n)!;
+
+function split(marker: number, ts: number, extra: Partial<Split> = {}): Split {
+  return {
+    marker,
+    timestamp: ts,
+    elapsed: ts,
+    coords: { latitude: 49.1 + marker / 1000, longitude: -123.1, altitude: 300, accuracy: 5 },
+    mode: "auto",
+    ...extra,
+  };
+}
+
+describe("exportHikesAsCsv", () => {
+  it("splits GPS into lat/lng/alt columns and formats time as local Excel date-time", () => {
+    const start = new Date(2026, 4, 24, 8, 0, 0).getTime(); // local 2026-05-24 08:00:00
+    const attempt: HikeAttempt = {
+      id: "h1",
+      date: new Date(start).toISOString(),
+      startTime: start,
+      endTime: start + 60_000,
+      splits: [split(1, start + 10_000)],
+      elevationData: [],
+      completed: true,
+      trailId: "grind",
+      startCoords: { latitude: 49.36, longitude: -123.08, altitude: 290, accuracy: 4 },
+    };
+    exportHikesAsCsv([attempt]);
+    const r = rows();
+    const header = r[0];
+    expect(header).toContain("Latitude");
+    expect(header).toContain("Longitude");
+    expect(header).toContain("Altitude (m)");
+    expect(header).toContain("Cumulative Trail Distance (m)");
+    expect(header).toContain("Segment Distance (m)");
+    // Start row local time, no T / Z, native Excel format.
+    const startRow = r[1];
+    expect(startRow[2]).toBe("2026-05-24 08:00:00");
+    expect(startRow[6]).toBe("49.3600000"); // latitude its own column
+    expect(startRow[7]).toBe("-123.0800000");
+  });
+
+  it("accumulates segment distance across a forgotten marker", () => {
+    const start = new Date(2026, 0, 1, 6, 0, 0).getTime();
+    const attempt: HikeAttempt = {
+      id: "h1",
+      date: new Date(start).toISOString(),
+      startTime: start,
+      splits: [
+        split(1, start + 1000),
+        split(2, start + 2000, { skipped: true }), // forgotten — no segment
+        split(3, start + 3000),
+      ],
+      elevationData: [],
+      completed: true,
+      trailId: "grind",
+    };
+    exportHikesAsCsv([attempt]);
+    const r = rows();
+    // header, start(0), m1, m2(skip), m3
+    const segIdx = r[0].indexOf("Segment Distance (m)");
+    const markerIdx = r[0].indexOf("Trail Marker Number");
+    const find = (mk: string) => r.find((row) => row[markerIdx] === mk)!;
+    const m2row = find("2");
+    const m3row = find("3");
+    expect(m2row[segIdx]).toBe(""); // forgotten marker: blank segment
+    // marker 3 segment spans marker 2's gap: dist(3) - dist(1)
+    const expected = (m(3).distanceM - m(1).distanceM).toFixed(1);
+    expect(m3row[segIdx]).toBe(expected);
+  });
+
+  it("orders hikes oldest-first regardless of input order", () => {
+    const older = new Date(2026, 0, 1, 6, 0, 0).getTime();
+    const newer = new Date(2026, 2, 1, 6, 0, 0).getTime();
+    const mk = (id: string, t: number): HikeAttempt => ({
+      id,
+      date: new Date(t).toISOString(),
+      startTime: t,
+      splits: [split(1, t + 1000)],
+      elevationData: [],
+      completed: true,
+      trailId: "grind",
+    });
+    exportHikesAsCsv([mk("new", newer), mk("old", older)]);
+    const r = rows();
+    expect(r[1][0]).toBe("old"); // first data row is the older hike
+  });
+});


### PR DESCRIPTION
## What

Reworks `exportHikesAsCsv` (the splits export) to import cleanly into Excel and carry per-marker trail distance for speed analysis.

| Req | Change |
|---|---|
| GPS for manual/tagged markers | Separate **Latitude / Longitude / Altitude (m)** columns (was one packed `"lat,lng,alt"` cell). Tags + manual markers surface GPS here. |
| Trail distance between markers | New **Cumulative Trail Distance (m)** and **Segment Distance (m)** columns. Segment = distance from last *captured* marker; forgotten markers leave it blank so the next captured marker accumulates across the gap. |
| Excel formatting | Timestamps as native-Excel **local** date-time `YYYY-MM-DD HH:MM:SS` (no `T`/`Z`); conditional quoting so numbers/dates import typed; `TRUE`/`FALSE` booleans. |
| Chronological sort | Rows sorted **oldest hike first**, markers ascending within each hike. |

## Why

The old export packed lat/lng/alt into one cell, used ISO-Z timestamps (imported as text in many Excel locales), had no distance data, and wasn't sorted — making it hard to chart speed across a hike.

## Notes for reviewer

- Distance source is authoritative trail data (`markersByNum[n].distanceM`); markers missing from the dataset (e.g. GRIND 4/8/13/27/32/34/37) use the split's saved `progressOverride`, else linear interpolation between known neighbours.
- Forgotten/skipped markers get a blank segment by design so speed segments span only captured-to-captured pairs.
- Raw GPS-track export (`exportGpsTracksAsCsv`) is unchanged — distance/marker columns don't apply there.
- No call site or test depended on the old column layout. New `export-csv.test.ts` covers column split, local time, gap accumulation, and ordering.
- Verified against a real 5-hike export (incl. tags + forgotten markers); all 27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)