### PR TITLE
Pace plan, live vs-plan deltas, and post-hike race report

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Track split times at numbered trail markers. Tap button as you pass each marker.
 - All hikes saved to browser localStorage. No account needed.
 - Compare up to 3 hikes side by side.
 - See best and average times per segment across all hikes.
+- **Pace plan ("Today's plan").** With at least one recorded hike, the start screen shows a plan of attack: a target finish (1% under your best reference), quarter-checkpoint times pinned to physical markers, and advice built from your own history (habitual second-half fade is detected and the plan deliberately holds time back early to spend up top; your biggest recent-average-vs-best segment gap is called out). During the hike the timer shows a live ± vs plan at the last captured marker, and quarter checkpoints are announced by voice.
+- **Race report.** Expanding a hike in History shows a report: total vs PB and vs recent moving average (EWMA of last 5), a cumulative ahead/behind chart across the full climb, and the first/second-half split.
 - Export any hike to CSV (marker, local time, lat/lng/alt, accuracy, cumulative + segment trail distance, logging mode, tags). Excel-friendly columns; rows sorted oldest hike first, markers ascending.
 
 ## Marker button — what it shows and why

--- a/src/components/ActiveHike.tsx
+++ b/src/components/ActiveHike.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useGps, type GpsPosition } from "@/hooks/use-gps";
 import { useWakeLock } from "@/hooks/use-wake-lock";
 import {
@@ -33,8 +33,10 @@ import {
 } from "@/lib/trails";
 import TrailProgress from "@/components/TrailProgress";
 import MapBackground from "@/components/MapBackground";
+import PacePlanCard from "@/components/PacePlanCard";
 import { speak, chime, unlockAudio, getAudioEnabled, setAudioEnabled } from "@/lib/audio";
 import { Volume2, VolumeX } from "lucide-react";
+import { buildPlan } from "@/lib/pace-plan";
 
 interface ActiveHikeProps {
   onFinish: () => void;
@@ -109,6 +111,15 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
   const [approachPassing, setApproachPassing] = useState(false);
   const [audioOn, setAudioOnState] = useState<boolean>(() => getAudioEnabled());
   const lastAnnouncedMarkerRef = useRef<number | null>(null);
+
+  // Pace plan from history — plan of attack for this hike + live "vs plan" deltas.
+  const plan = useMemo(
+    () => buildPlan(loadAttempts(), trail),
+    // Recompute when a hike starts/ends or the selected trail changes.
+    [trail, isRunning], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+  const planRef = useRef(plan);
+  useEffect(() => { planRef.current = plan; }, [plan]);
 
   // Notify parent of active state
   useEffect(() => { onActiveChange?.(isRunning); }, [isRunning, onActiveChange]);
@@ -269,7 +280,19 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
       approachRef.current = null;
       setApproachInZone(false);
       setApproachPassing(false);
-      if (!split.skipped) chime("logged");
+      if (!split.skipped) {
+        chime("logged");
+        // Eyes-free pacing: announce ahead/behind plan at the quarter checkpoints.
+        const p = planRef.current;
+        const target = p?.cumMsByMarker.get(split.marker);
+        if (p && target !== undefined && p.checkpoints.some((c) => c.marker === split.marker)) {
+          const deltaS = Math.round((split.elapsed - target) / 1000);
+          const mm = Math.floor(Math.abs(deltaS) / 60);
+          const ss = Math.abs(deltaS) % 60;
+          const spoken = mm > 0 ? `${mm} minute${mm === 1 ? "" : "s"} ${ss} seconds` : `${ss} seconds`;
+          speak(deltaS <= 0 ? `${spoken} ahead of plan` : `${spoken} behind plan`);
+        }
+      }
     },
     []
   );
@@ -570,6 +593,18 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
     return getProgressForMarker(trail, attempt ? attempt.splits.length : 0);
   })();
 
+  // Live "vs plan" delta at the last captured marker.
+  const planDelta = (() => {
+    if (!plan || !attempt) return null;
+    for (let i = attempt.splits.length - 1; i >= 0; i--) {
+      const s = attempt.splits[i];
+      if (s.skipped) continue;
+      const target = plan.cumMsByMarker.get(s.marker);
+      if (target !== undefined) return { marker: s.marker, deltaMs: s.elapsed - target };
+    }
+    return null;
+  })();
+
   // Pre-start view
   if (!isRunning && !attempt) {
     const gps = gpsState(position);
@@ -625,6 +660,8 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
         </div>
 
         {trailSwitch}
+
+        {plan && <PacePlanCard plan={plan} />}
 
         {!startReady ? (
           <div className="flex flex-col items-center gap-3">
@@ -706,6 +743,14 @@ export default function ActiveHike({ onFinish, onActiveChange, onHelpOpen, trail
                       {(markerProgress.distanceM / 1000).toFixed(2)} km / {TRAIL_DISTANCE_KM.toFixed(2)} km ({markerProgress.distancePct.toFixed(0)}%)
                     </span>
                   </div>
+                  {planDelta && (
+                    <div className={`flex items-center justify-center gap-1 text-sm font-semibold ${planDelta.deltaMs <= 0 ? "text-success" : "text-warning"}`}>
+                      <span>
+                        {planDelta.deltaMs <= 0 ? "−" : "+"}{formatDuration(Math.abs(planDelta.deltaMs))} vs plan
+                        <span className="text-muted-foreground font-normal"> @ m{planDelta.marker}</span>
+                      </span>
+                    </div>
+                  )}
                 </div>
           </div>
           {/* GPS accuracy indicator */}

--- a/src/components/HikeHistory.tsx
+++ b/src/components/HikeHistory.tsx
@@ -13,6 +13,7 @@ import {
 import { TRAILS, type TrailId } from "@/lib/trails";
 import { Trophy, Calendar, Clock, Trash2, Download, ChevronDown, ChevronUp, Tag as TagIcon, MoreVertical, MapPin, ArrowRight } from "lucide-react";
 import HikeComparison from "./HikeComparison";
+import HikeReport from "./HikeReport";
 
 interface HikeHistoryProps {
   attempts: HikeAttempt[];
@@ -467,6 +468,7 @@ export default function HikeHistory({ attempts, onRefresh }: HikeHistoryProps) {
                       );
                     })()}
                   </div>
+                  <HikeReport attempt={a} trail={trail} attempts={completed} />
                 </div>
               )}
             </div>

--- a/src/components/HikeReport.tsx
+++ b/src/components/HikeReport.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import type { HikeAttempt } from "@/lib/hike-store";
+import { formatDuration } from "@/lib/hike-store";
+import type { Trail } from "@/lib/trails";
+import {
+  cumulativeTimes,
+  personalBest,
+  recentAverage,
+  fadeAnalysis,
+  type PaceReference,
+} from "@/lib/pace-plan";
+import { TrendingDown, TrendingUp, Scale } from "lucide-react";
+
+interface HikeReportProps {
+  attempt: HikeAttempt;
+  trail: Trail;
+  /** Full history — references are computed from the *other* attempts. */
+  attempts: HikeAttempt[];
+}
+
+const CHART_W = 300;
+const CHART_H = 90;
+const PAD_X = 6;
+const PAD_Y = 12;
+
+function signed(ms: number): string {
+  const sign = ms > 0 ? "+" : ms < 0 ? "−" : "±";
+  return `${sign}${formatDuration(Math.abs(ms))}`;
+}
+
+/**
+ * Post-hike race report: cumulative time delta vs PB and recent average at
+ * every captured marker, plus half-split fade. Rendered inside the expanded
+ * history card.
+ */
+export default function HikeReport({ attempt, trail, attempts }: HikeReportProps) {
+  const others = useMemo(() => attempts.filter((a) => a.id !== attempt.id), [attempts, attempt.id]);
+  const pb = useMemo(() => personalBest(others, trail), [others, trail]);
+  const recent = useMemo(() => recentAverage(others, trail), [others, trail]);
+  const curve = useMemo(() => cumulativeTimes(attempt, trail), [attempt, trail]);
+  const fade = useMemo(() => fadeAnalysis(attempt, trail), [attempt, trail]);
+
+  const deltaSeries = (ref: PaceReference | null) => {
+    if (!ref) return [];
+    return curve
+      .filter((p) => ref.cumMsByMarker.has(p.marker))
+      .map((p) => ({ x: p.distancePct, deltaMs: p.cumMs - ref.cumMsByMarker.get(p.marker)! }));
+  };
+
+  const vsPb = useMemo(() => deltaSeries(pb), [curve, pb]); // eslint-disable-line react-hooks/exhaustive-deps
+  const vsRecent = useMemo(() => deltaSeries(recent), [curve, recent]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isNewPb = pb !== null && attempt.totalTime !== undefined && attempt.totalTime < pb.totalMs;
+
+  if (!pb && !fade) return null;
+
+  // Chart scale across both series. Positive delta = behind (slower) → drawn below the zero line.
+  const allDeltas = [...vsPb, ...vsRecent].map((p) => p.deltaMs);
+  const maxAbs = Math.max(30_000, ...allDeltas.map((d) => Math.abs(d)));
+  const toX = (pct: number) => PAD_X + (pct / 100) * (CHART_W - 2 * PAD_X);
+  const toY = (deltaMs: number) => CHART_H / 2 + (deltaMs / maxAbs) * (CHART_H / 2 - PAD_Y);
+  const path = (pts: { x: number; deltaMs: number }[]) =>
+    pts.map((p, i) => `${i === 0 ? "M" : "L"}${toX(p.x).toFixed(1)},${toY(p.deltaMs).toFixed(1)}`).join(" ");
+
+  const finalVsPb = vsPb.length > 0 ? vsPb[vsPb.length - 1].deltaMs : null;
+  const finalVsRecent = vsRecent.length > 0 ? vsRecent[vsRecent.length - 1].deltaMs : null;
+
+  return (
+    <div className="mt-3 pt-3 border-t border-border/60">
+      <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-2">Race report</p>
+
+      {/* Stat chips */}
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        {isNewPb && (
+          <span className="text-[11px] font-bold px-2 py-1 rounded-lg bg-accent/15 border border-accent/35 text-accent">
+            New PB {finalVsPb !== null ? `(${signed(finalVsPb)})` : ""}
+          </span>
+        )}
+        {!isNewPb && finalVsPb !== null && (
+          <span className={`text-[11px] font-bold px-2 py-1 rounded-lg border flex items-center gap-1 ${finalVsPb <= 0 ? "bg-primary/10 border-primary/30 text-primary" : "bg-muted border-border text-muted-foreground"}`}>
+            {finalVsPb <= 0 ? <TrendingDown className="w-3 h-3" /> : <TrendingUp className="w-3 h-3" />}
+            vs PB {signed(finalVsPb)}
+          </span>
+        )}
+        {finalVsRecent !== null && (
+          <span className={`text-[11px] font-bold px-2 py-1 rounded-lg border flex items-center gap-1 ${finalVsRecent <= 0 ? "bg-primary/10 border-primary/30 text-primary" : "bg-muted border-border text-muted-foreground"}`}>
+            {finalVsRecent <= 0 ? <TrendingDown className="w-3 h-3" /> : <TrendingUp className="w-3 h-3" />}
+            vs recent avg {signed(finalVsRecent)}
+          </span>
+        )}
+        {fade && (
+          <span className="text-[11px] font-bold px-2 py-1 rounded-lg bg-muted border border-border text-muted-foreground flex items-center gap-1">
+            <Scale className="w-3 h-3" />
+            Halves {formatDuration(fade.firstHalfMs)} / {formatDuration(fade.secondHalfMs)}
+          </span>
+        )}
+      </div>
+
+      {/* Cumulative delta chart */}
+      {(vsPb.length > 1 || vsRecent.length > 1) && (
+        <div>
+          <svg viewBox={`0 0 ${CHART_W} ${CHART_H}`} className="block w-full" style={{ height: 84 }}>
+            {/* zero line */}
+            <line x1={PAD_X} y1={CHART_H / 2} x2={CHART_W - PAD_X} y2={CHART_H / 2} strokeWidth="1" strokeDasharray="3 3" className="stroke-muted-foreground/40" />
+            <text x={PAD_X} y={CHART_H / 2 - 4} className="fill-muted-foreground/60" fontSize="7">ahead ↑</text>
+            <text x={PAD_X} y={CHART_H / 2 + 10} className="fill-muted-foreground/60" fontSize="7">behind ↓</text>
+            {vsRecent.length > 1 && (
+              <path d={path(vsRecent)} fill="none" strokeWidth="1.5" className="stroke-muted-foreground/50" />
+            )}
+            {vsPb.length > 1 && (
+              <path d={path(vsPb)} fill="none" strokeWidth="2" className="stroke-accent" />
+            )}
+          </svg>
+          <div className="flex gap-3 justify-center text-[10px] text-muted-foreground">
+            {vsPb.length > 1 && (
+              <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-accent inline-block rounded" /> vs PB</span>
+            )}
+            {vsRecent.length > 1 && (
+              <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-muted-foreground/50 inline-block rounded" /> vs recent avg</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PacePlanCard.tsx
+++ b/src/components/PacePlanCard.tsx
@@ -1,0 +1,57 @@
+import type { PacePlan } from "@/lib/pace-plan";
+import { formatDuration } from "@/lib/hike-store";
+import { Target } from "lucide-react";
+
+interface PacePlanCardProps {
+  plan: PacePlan;
+}
+
+/**
+ * "Plan of attack" card on the pre-start screen: target finish time, quarter
+ * checkpoint times (with the physical marker to watch for), and pacing advice
+ * derived from the hiker's own history.
+ */
+export default function PacePlanCard({ plan }: PacePlanCardProps) {
+  return (
+    <div className="w-full max-w-xs bg-card border border-border rounded-2xl p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="w-7 h-7 rounded-lg flex items-center justify-center bg-primary/10 border border-primary/25 text-primary">
+          <Target className="w-4 h-4" />
+        </span>
+        <div className="flex-1">
+          <p className="text-[10px] uppercase tracking-widest text-muted-foreground leading-none">Today's plan</p>
+          <p className="text-lg font-mono-display font-bold text-primary leading-tight tabular-nums">
+            {formatDuration(plan.targetTotalMs)}
+            <span className="ml-2 text-[10px] font-sans font-semibold text-muted-foreground uppercase tracking-wide">
+              beat {plan.basis === "pb" ? "PB" : "recent avg"}
+            </span>
+          </p>
+        </div>
+      </div>
+
+      {/* Quarter checkpoints */}
+      <div className="grid grid-cols-4 gap-1 mb-2">
+        {plan.checkpoints.map((c) => (
+          <div key={c.label} className="bg-muted/50 rounded-lg px-1 py-1.5 text-center">
+            <p className="text-[9px] text-muted-foreground leading-none mb-0.5">
+              {c.label}
+              {c.marker !== null && c.label !== "Finish" ? ` · m${c.marker}` : ""}
+            </p>
+            <p className="text-xs font-mono-display font-bold tabular-nums">{formatDuration(c.targetMs)}</p>
+          </div>
+        ))}
+      </div>
+
+      {plan.advice.length > 0 && (
+        <ul className="space-y-1">
+          {plan.advice.map((line, i) => (
+            <li key={i} className="text-[11px] text-muted-foreground leading-snug flex gap-1.5">
+              <span className="text-primary flex-none">▸</span>
+              {line}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/pace-plan.ts
+++ b/src/lib/pace-plan.ts
@@ -1,0 +1,296 @@
+// Pace planning + post-hike analysis.
+//
+// Everything works off cumulative time-at-marker curves. Skipped splits are
+// excluded — their timestamps record when the app *noticed* the miss, not when
+// the hiker passed the marker, so they carry no pace information.
+
+import type { HikeAttempt, Split } from "./hike-store";
+import { attemptTrailId } from "./hike-store";
+import { interpolateMarkerProgress, type Trail, type TrailId } from "./trails";
+
+export interface MarkerTime {
+  marker: number;
+  cumMs: number;
+  /** 0..100 along-trail distance for this marker. */
+  distancePct: number;
+}
+
+/** Distance % for a split, honouring manual-mode progress overrides. */
+function splitDistancePct(trail: Trail, s: Split): number {
+  if (s.progressOverride) return s.progressOverride.distancePct;
+  const rec = trail.markersByNum.get(s.marker);
+  if (rec) return rec.distancePct;
+  return interpolateMarkerProgress(trail, s.marker).distancePct;
+}
+
+/** Cumulative time curve for one completed attempt (non-skipped splits + finish). */
+export function cumulativeTimes(attempt: HikeAttempt, trail: Trail): MarkerTime[] {
+  const out: MarkerTime[] = [];
+  for (const s of attempt.splits) {
+    if (s.skipped) continue;
+    out.push({ marker: s.marker, cumMs: s.elapsed, distancePct: splitDistancePct(trail, s) });
+  }
+  if (attempt.completed && attempt.totalTime) {
+    out.push({ marker: trail.finishMarker, cumMs: attempt.totalTime, distancePct: 100 });
+  }
+  return out;
+}
+
+/** Interpolated cumulative time (ms) at a given distance %, or null when out of range. */
+export function timeAtDistancePct(curve: MarkerTime[], pct: number): number | null {
+  if (curve.length === 0) return null;
+  const pts = [{ marker: 0, cumMs: 0, distancePct: 0 }, ...curve];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i];
+    const b = pts[i + 1];
+    if (pct >= a.distancePct && pct <= b.distancePct) {
+      const span = b.distancePct - a.distancePct;
+      const t = span > 0 ? (pct - a.distancePct) / span : 0;
+      return a.cumMs + t * (b.cumMs - a.cumMs);
+    }
+  }
+  return pct > pts[pts.length - 1].distancePct ? null : 0;
+}
+
+export interface PaceReference {
+  label: string;
+  totalMs: number;
+  /** Cumulative target time per marker number. */
+  cumMsByMarker: Map<number, number>;
+}
+
+function completedOnTrail(attempts: HikeAttempt[], trailId: TrailId): HikeAttempt[] {
+  return attempts
+    .filter((a) => a.completed && a.totalTime && attemptTrailId(a) === trailId)
+    .sort((a, b) => a.startTime - b.startTime); // oldest → newest
+}
+
+export function personalBest(attempts: HikeAttempt[], trail: Trail): PaceReference | null {
+  const done = completedOnTrail(attempts, trail.id);
+  if (done.length === 0) return null;
+  const best = done.reduce((a, b) => (a.totalTime! <= b.totalTime! ? a : b));
+  const curve = cumulativeTimes(best, trail);
+  return {
+    label: "PB",
+    totalMs: best.totalTime!,
+    cumMsByMarker: new Map(curve.map((p) => [p.marker, p.cumMs])),
+  };
+}
+
+const EWMA_ALPHA = 0.4;
+const RECENT_N = 5;
+
+/**
+ * Exponentially-weighted moving average of the last few hikes, newest
+ * weighted heaviest. Per-marker EWMA over the attempts that captured that
+ * marker, so one forgotten tap doesn't hole the whole reference.
+ */
+export function recentAverage(attempts: HikeAttempt[], trail: Trail): PaceReference | null {
+  const done = completedOnTrail(attempts, trail.id).slice(-RECENT_N);
+  if (done.length === 0) return null;
+
+  const ewma = new Map<number, number>(); // marker → running average
+  let totalEwma: number | null = null;
+  for (const a of done) {
+    for (const p of cumulativeTimes(a, trail)) {
+      const prev = ewma.get(p.marker);
+      ewma.set(p.marker, prev === undefined ? p.cumMs : prev + EWMA_ALPHA * (p.cumMs - prev));
+    }
+    totalEwma = totalEwma === null ? a.totalTime! : totalEwma + EWMA_ALPHA * (a.totalTime! - totalEwma);
+  }
+  return { label: "Recent avg", totalMs: totalEwma!, cumMsByMarker: ewma };
+}
+
+export interface FadeAnalysis {
+  firstHalfMs: number;
+  secondHalfMs: number;
+  /** secondHalf / firstHalf. Terrain makes ~this trail's PB ratio the baseline, not 1.0. */
+  ratio: number;
+}
+
+export function fadeAnalysis(attempt: HikeAttempt, trail: Trail): FadeAnalysis | null {
+  const curve = cumulativeTimes(attempt, trail);
+  if (!attempt.totalTime || curve.length < 3) return null;
+  const half = timeAtDistancePct(curve, 50);
+  if (half === null || half <= 0) return null;
+  const second = attempt.totalTime - half;
+  return { firstHalfMs: half, secondHalfMs: second, ratio: second / half };
+}
+
+export interface PlanCheckpoint {
+  label: string;
+  distancePct: number;
+  /** Nearest real marker at/after this distance, when one exists. */
+  marker: number | null;
+  targetMs: number;
+}
+
+export interface PacePlan {
+  targetTotalMs: number;
+  /** Basis for the target: beating PB or beating the recent average. */
+  basis: "pb" | "recent";
+  checkpoints: PlanCheckpoint[];
+  /** Cumulative target per marker — used for live "vs plan" deltas. */
+  cumMsByMarker: Map<number, number>;
+  advice: string[];
+  hikeCount: number;
+}
+
+const CHECKPOINTS = [
+  { label: "¼", pct: 25 },
+  { label: "½", pct: 50 },
+  { label: "¾", pct: 75 },
+  { label: "Finish", pct: 100 },
+];
+
+/**
+ * Build the next-hike plan. Target = beat PB by pacing to the *shape* of the
+ * recent average, fade flattened: the historical curve is corrected so the
+ * second half doesn't decay, then scaled to the target total. This converts
+ * "you always die at the top" into concrete slower-early / stronger-late
+ * checkpoint times.
+ */
+export function buildPlan(attempts: HikeAttempt[], trail: Trail): PacePlan | null {
+  const done = completedOnTrail(attempts, trail.id);
+  if (done.length === 0) return null;
+
+  const pb = personalBest(attempts, trail)!;
+  const recent = recentAverage(attempts, trail)!;
+  const shapeRef = recent; // recent shape reflects current fitness better than a months-old PB
+
+  // Target: nudge under the better of PB / recent average.
+  const basis: PacePlan["basis"] = pb.totalMs <= recent.totalMs ? "pb" : "recent";
+  const targetTotalMs = Math.min(pb.totalMs, recent.totalMs) * 0.99;
+
+  // Median fade across recent attempts — drives the flattening + advice.
+  const fades = done
+    .slice(-RECENT_N)
+    .map((a) => fadeAnalysis(a, trail))
+    .filter((f): f is FadeAnalysis => f !== null)
+    .map((f) => f.ratio)
+    .sort((a, b) => a - b);
+  const medianFade = fades.length > 0 ? fades[Math.floor(fades.length / 2)] : null;
+
+  // Shape: cumulative fraction of total time at each marker, from the recent
+  // average, with the second half compressed by the fade so the plan front-
+  // loads caution instead of replaying the blow-up.
+  const flatten = medianFade !== null && medianFade > 1.02 ? Math.sqrt(medianFade) : 1;
+  const markers = [...trail.markers].sort((a, b) => a.distanceM - b.distanceM);
+  const cumMsByMarker = new Map<number, number>();
+  const shapeCurve: MarkerTime[] = [...shapeRef.cumMsByMarker.entries()]
+    .map(([marker, cumMs]) => {
+      const rec = trail.markersByNum.get(marker);
+      return rec ? { marker, cumMs, distancePct: rec.distancePct } : { marker, cumMs, distancePct: marker === trail.finishMarker ? 100 : -1 };
+    })
+    .filter((p) => p.distancePct >= 0)
+    .sort((a, b) => a.distancePct - b.distancePct);
+
+  const shapeAt = (pct: number): number | null => {
+    const t = timeAtDistancePct(shapeCurve, pct);
+    return t === null ? null : t / shapeRef.totalMs;
+  };
+
+  // Fade correction: stretch first-half fractions up, pull second-half down,
+  // renormalised so 100% still maps to 1.0.
+  const corrected = (pct: number): number | null => {
+    const f = shapeAt(pct);
+    if (f === null) return null;
+    if (flatten === 1) return f;
+    // Weight: first half slower (fractions grow), second half faster.
+    const w = pct <= 50 ? flatten : 1 / flatten;
+    const half = shapeAt(50) ?? 0.5;
+    if (pct <= 50) {
+      return Math.min(1, f * ((half * w) / half));
+    }
+    const tail = 1 - half;
+    const correctedHalf = Math.min(1, half * flatten);
+    return correctedHalf + ((f - half) / tail) * (1 - correctedHalf);
+  };
+
+  for (const m of markers) {
+    const frac = corrected(m.distancePct);
+    if (frac !== null) cumMsByMarker.set(m.marker, frac * targetTotalMs);
+  }
+  cumMsByMarker.set(trail.finishMarker, targetTotalMs);
+
+  const checkpoints: PlanCheckpoint[] = CHECKPOINTS.map(({ label, pct }) => {
+    const nearest = markers.find((m) => m.distancePct >= pct) ?? null;
+    const frac = corrected(pct) ?? pct / 100;
+    return {
+      label,
+      distancePct: pct,
+      marker: pct === 100 ? trail.finishMarker : nearest?.marker ?? null,
+      targetMs: pct === 100 ? targetTotalMs : frac * targetTotalMs,
+    };
+  });
+
+  // Advice.
+  const advice: string[] = [];
+  if (medianFade !== null && medianFade > 1.08) {
+    const pctSlower = Math.round((medianFade - 1) * 100);
+    advice.push(
+      `You typically run the second half ${pctSlower}% slower than the first. Start easier: the plan holds back ~${Math.round(((flatten - 1) * (shapeAt(50) ?? 0.5) * targetTotalMs) / 1000 / 60 * 10) / 10} min in the first half to spend up top.`,
+    );
+  } else if (medianFade !== null && medianFade < 0.98) {
+    advice.push("You finish faster than you start — you likely have time banked in a harder first half.");
+  } else if (medianFade !== null) {
+    advice.push("Your halves are well balanced. Gains now come from overall fitness, not pacing.");
+  }
+
+  // Biggest opportunity: segment (between consecutive commonly-captured
+  // markers) with the largest gap between recent average and personal
+  // gold-split (best-ever segment time).
+  const opportunity = biggestOpportunity(done.slice(-RECENT_N), trail);
+  if (opportunity) {
+    advice.push(
+      `Biggest opportunity: markers ${opportunity.fromMarker}–${opportunity.toMarker}. Your best is ${fmtMin(opportunity.bestMs)}, recent average ${fmtMin(opportunity.avgMs)} — ${fmtMin(opportunity.avgMs - opportunity.bestMs)} on the table.`,
+    );
+  }
+  if (done.length < 3) {
+    advice.push("Plan confidence is low with under 3 recorded hikes — log a few more for a sharper plan.");
+  }
+
+  return { targetTotalMs, basis, checkpoints, cumMsByMarker, advice, hikeCount: done.length };
+}
+
+interface Opportunity {
+  fromMarker: number;
+  toMarker: number;
+  bestMs: number;
+  avgMs: number;
+}
+
+function biggestOpportunity(attempts: HikeAttempt[], trail: Trail): Opportunity | null {
+  // Segment times keyed "from→to" over consecutive captured markers.
+  const segs = new Map<string, { from: number; to: number; times: number[] }>();
+  for (const a of attempts) {
+    const curve = cumulativeTimes(a, trail);
+    const withStart = [{ marker: 0, cumMs: 0, distancePct: 0 }, ...curve];
+    for (let i = 1; i < withStart.length; i++) {
+      const from = withStart[i - 1];
+      const to = withStart[i];
+      const k = `${from.marker}→${to.marker}`;
+      const e = segs.get(k) ?? { from: from.marker, to: to.marker, times: [] };
+      e.times.push(to.cumMs - from.cumMs);
+      segs.set(k, e);
+    }
+  }
+  let best: Opportunity | null = null;
+  for (const { from, to, times } of segs.values()) {
+    if (times.length < 2) continue; // need repeats to call it a pattern
+    const bestMs = Math.min(...times);
+    const avgMs = times.reduce((a, b) => a + b, 0) / times.length;
+    const gap = avgMs - bestMs;
+    if (gap > 15_000 && (!best || gap > best.avgMs - best.bestMs)) {
+      best = { fromMarker: from, toMarker: to, bestMs, avgMs };
+    }
+  }
+  return best;
+}
+
+function fmtMin(ms: number): string {
+  const totalSec = Math.round(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}

--- a/src/test/pace-plan.test.ts
+++ b/src/test/pace-plan.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  cumulativeTimes,
+  timeAtDistancePct,
+  personalBest,
+  recentAverage,
+  fadeAnalysis,
+  buildPlan,
+} from "@/lib/pace-plan";
+import { GRIND_TRAIL } from "@/lib/trails";
+import type { HikeAttempt, Split } from "@/lib/hike-store";
+
+const trail = GRIND_TRAIL;
+
+/** Build a completed attempt with cumulative times spread linearly over known markers. */
+function makeAttempt(id: string, totalMs: number, opts?: { fadeRatio?: number; startTime?: number; skipMarkers?: number[] }): HikeAttempt {
+  const fade = opts?.fadeRatio ?? 1;
+  const startTime = opts?.startTime ?? 1_700_000_000_000;
+  const splits: Split[] = [];
+  for (const m of trail.markers) {
+    if (m.marker === 0 || m.marker >= trail.finishMarker) continue;
+    const frac = m.distancePct / 100;
+    // fade: second half takes `fade`× the time-per-distance of the first half.
+    const halfShare = 1 / (1 + fade);
+    const cumFrac = frac <= 0.5 ? frac * 2 * halfShare : halfShare + (frac - 0.5) * 2 * (1 - halfShare);
+    const elapsed = Math.round(cumFrac * totalMs);
+    if (opts?.skipMarkers?.includes(m.marker)) {
+      splits.push({ marker: m.marker, timestamp: startTime + elapsed, elapsed, skipped: true });
+    } else {
+      splits.push({ marker: m.marker, timestamp: startTime + elapsed, elapsed });
+    }
+  }
+  return {
+    id,
+    date: new Date(startTime).toISOString(),
+    startTime,
+    endTime: startTime + totalMs,
+    totalTime: totalMs,
+    splits,
+    elevationData: [],
+    completed: true,
+    trailId: "grind",
+  };
+}
+
+describe("cumulativeTimes", () => {
+  it("excludes skipped splits and appends the finish", () => {
+    const a = makeAttempt("a", 3_600_000, { skipMarkers: [trail.markers[2].marker] });
+    const curve = cumulativeTimes(a, trail);
+    expect(curve.some((p) => p.marker === trail.markers[2].marker)).toBe(false);
+    expect(curve[curve.length - 1]).toMatchObject({ marker: trail.finishMarker, cumMs: 3_600_000, distancePct: 100 });
+  });
+});
+
+describe("timeAtDistancePct", () => {
+  it("interpolates between markers", () => {
+    const a = makeAttempt("a", 3_600_000);
+    const curve = cumulativeTimes(a, trail);
+    const t50 = timeAtDistancePct(curve, 50)!;
+    expect(t50).toBeGreaterThan(0);
+    expect(t50).toBeLessThan(3_600_000);
+    // Even pacing (fade=1) → 50% distance ≈ 50% time.
+    expect(t50 / 3_600_000).toBeCloseTo(0.5, 1);
+  });
+});
+
+describe("personalBest / recentAverage", () => {
+  it("PB picks fastest total, recent average weights newest heaviest", () => {
+    const attempts = [
+      makeAttempt("old-fast", 3_000_000, { startTime: 1_700_000_000_000 }),
+      makeAttempt("mid", 3_800_000, { startTime: 1_700_100_000_000 }),
+      makeAttempt("new-slow", 4_000_000, { startTime: 1_700_200_000_000 }),
+    ];
+    const pb = personalBest(attempts, trail)!;
+    expect(pb.totalMs).toBe(3_000_000);
+    const avg = recentAverage(attempts, trail)!;
+    // EWMA of 3.0M, 3.8M, 4.0M (α=0.4, newest last) sits between mid and newest.
+    expect(avg.totalMs).toBeGreaterThan(3_000_000);
+    expect(avg.totalMs).toBeLessThan(4_000_000);
+    expect(avg.totalMs).toBeGreaterThan(3_400_000); // pulled toward recent slow runs
+  });
+
+  it("returns null with no completed attempts on the trail", () => {
+    expect(personalBest([], trail)).toBeNull();
+    expect(recentAverage([], trail)).toBeNull();
+  });
+});
+
+describe("fadeAnalysis", () => {
+  it("detects a fade (second half slower)", () => {
+    const a = makeAttempt("fade", 3_600_000, { fadeRatio: 1.3 });
+    const f = fadeAnalysis(a, trail)!;
+    expect(f.ratio).toBeGreaterThan(1.15);
+    expect(f.firstHalfMs + f.secondHalfMs).toBeCloseTo(3_600_000, -3);
+  });
+
+  it("even pacing → ratio ≈ 1", () => {
+    const a = makeAttempt("even", 3_600_000, { fadeRatio: 1 });
+    const f = fadeAnalysis(a, trail)!;
+    expect(f.ratio).toBeGreaterThan(0.9);
+    expect(f.ratio).toBeLessThan(1.1);
+  });
+});
+
+describe("buildPlan", () => {
+  it("targets just under the best reference and flattens a habitual fade", () => {
+    const attempts = [
+      makeAttempt("h1", 3_700_000, { fadeRatio: 1.25, startTime: 1_700_000_000_000 }),
+      makeAttempt("h2", 3_650_000, { fadeRatio: 1.3, startTime: 1_700_100_000_000 }),
+      makeAttempt("h3", 3_600_000, { fadeRatio: 1.25, startTime: 1_700_200_000_000 }),
+    ];
+    const plan = buildPlan(attempts, trail)!;
+    expect(plan.targetTotalMs).toBeLessThan(3_600_000);
+    expect(plan.checkpoints).toHaveLength(4);
+    expect(plan.checkpoints[3].targetMs).toBeCloseTo(plan.targetTotalMs, 5);
+
+    // Fade-flattened plan: planned first half takes a LARGER share of total
+    // time than the historical first half did (i.e. deliberately slower start).
+    const half = plan.checkpoints.find((c) => c.label === "½")!;
+    const historicalHalfShare = 1 / (1 + 1.25); // ≈ 0.444
+    expect(half.targetMs / plan.targetTotalMs).toBeGreaterThan(historicalHalfShare);
+
+    // Checkpoint targets monotonically increase.
+    const times = plan.checkpoints.map((c) => c.targetMs);
+    expect([...times].sort((x, y) => x - y)).toEqual(times);
+
+    // Fade advice present.
+    expect(plan.advice.some((s) => s.includes("second half"))).toBe(true);
+  });
+
+  it("per-marker targets are monotonic in distance", () => {
+    const attempts = [
+      makeAttempt("h1", 3_700_000, { fadeRatio: 1.25, startTime: 1_700_000_000_000 }),
+      makeAttempt("h2", 3_600_000, { fadeRatio: 1.25, startTime: 1_700_100_000_000 }),
+    ];
+    const plan = buildPlan(attempts, trail)!;
+    const ordered = [...trail.markers]
+      .sort((a, b) => a.distanceM - b.distanceM)
+      .map((m) => plan.cumMsByMarker.get(m.marker))
+      .filter((t): t is number => t !== undefined);
+    for (let i = 1; i < ordered.length; i++) {
+      expect(ordered[i]).toBeGreaterThanOrEqual(ordered[i - 1] - 1); // float tolerance
+    }
+  });
+
+  it("null with no history", () => {
+    expect(buildPlan([], trail)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Turns the recorded hike history into forward-looking pacing guidance, so each hike starts with a plan of attack and ends with a report of how it went vs PB and the recent moving average.

- **`src/lib/pace-plan.ts`** — analysis core:
  - Cumulative time-at-marker curves per attempt. Skipped splits are excluded: their timestamps record when the app *noticed* the miss, not when the hiker passed the marker, so they carry no pace information.
  - References: personal best + recent average (EWMA over last 5 hikes, α=0.4, newest weighted heaviest, per-marker so one forgotten tap doesn't hole the reference).
  - Half-split fade analysis (time to 50% trail distance vs the rest, interpolated along the marker distance table).
  - `buildPlan()`: target = 1% under the best of PB / recent avg, checkpoint shape taken from the recent average with the habitual second-half fade flattened — the plan deliberately holds time back early to spend up top. Advice bullets call out the fade percentage and the segment with the biggest recent-average-vs-best gap.
- **`PacePlanCard`** — "Today's plan" on the pre-start screen: target finish, ¼/½/¾/Finish checkpoint times pinned to physical marker numbers, advice bullets.
- **`ActiveHike`** — live `−0:42 vs plan @ m12` line under the timer after every captured marker; ahead/behind spoken at quarter checkpoints for eyes-free pacing.
- **`HikeReport`** — race report inside expanded History cards: New PB / vs PB / vs recent avg chips, cumulative ahead-behind SVG chart across the whole climb, first/second-half split.

## Why

The app captured splits well but reported only raw per-marker best/avg tables — nothing said *where* time is lost or *what to do differently next time*. The delta chart shows where a hike was won or lost; the plan converts the pattern into concrete checkpoint times.

## Notes for review

- Everything is iOS-Safari-safe: plain TS + SVG + `speechSynthesis` (already used by the app). A Web-Bluetooth heart-rate/effort-alert feature was prototyped and deliberately dropped because the app is used exclusively on iOS.
- References in `HikeReport` are computed from the *other* attempts, so a hike is never compared against itself (a new PB shows "New PB" vs the previous one).
- Fade flattening only kicks in when median fade > 1.02; with balanced halves the plan follows the historical shape unchanged.
- 9 new unit tests in `src/test/pace-plan.test.ts` (48 → run `npm test`); verified end-to-end in the browser with seeded history (plan card, live delta, report chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)